### PR TITLE
Add frameid param to imu node

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -518,6 +518,15 @@ as product ID, serial number, firmware version, and firmware date on the
 
 Setting this parameter to false will disable identification data publishing.
 
+frame_id
+""""""""
+
+**Type:** string
+**Default:** "imu"
+
+The TF frame ID for the IMU sensor (e.g., `source_x/imu`). Useful when multiple
+IMUs are used in the same system to uniquely identify each sensor's data.
+
 
 IMU parameters
 ^^^^^^^^^^^^^^

--- a/include/adi_imu/imu_data_provider.h
+++ b/include/adi_imu/imu_data_provider.h
@@ -20,6 +20,8 @@
 #ifndef ADI_IMU__IMU_DATA_PROVIDER_H_
 #define ADI_IMU__IMU_DATA_PROVIDER_H_
 
+#include <string>
+
 #include "adi_imu/iio_wrapper.h"
 #include "adi_imu/imu_data_provider_interface.h"
 
@@ -43,6 +45,12 @@ public:
   ~ImuDataProvider();
 
   /**
+   * @brief Set the frame ID for the IMU messages.
+   * @param frame_id The TF frame ID to use for the IMU messages.
+   */
+  void setFrameId(const std::string & frame_id) override;
+
+  /**
    * @brief Populate Imu message with measured data.
    * @param message Message containing the measured data.
    * @return Return true if the message parameter is successfully populated with
@@ -53,6 +61,9 @@ public:
 private:
   /*! This data member is used to access sensor information via libiio. */
   IIOWrapper m_iio_wrapper;
+
+  /*! The TF frame ID for the IMU sensor. */
+  std::string m_frame_id;
 };
 
 }  // namespace adi_imu

--- a/include/adi_imu/imu_data_provider_interface.h
+++ b/include/adi_imu/imu_data_provider_interface.h
@@ -20,9 +20,8 @@
 #ifndef ADI_IMU__IMU_DATA_PROVIDER_INTERFACE_H_
 #define ADI_IMU__IMU_DATA_PROVIDER_INTERFACE_H_
 
-#include <string>
-
 #include <sensor_msgs/msg/imu.hpp>
+#include <string>
 
 namespace adi_imu
 {

--- a/include/adi_imu/imu_data_provider_interface.h
+++ b/include/adi_imu/imu_data_provider_interface.h
@@ -20,6 +20,8 @@
 #ifndef ADI_IMU__IMU_DATA_PROVIDER_INTERFACE_H_
 #define ADI_IMU__IMU_DATA_PROVIDER_INTERFACE_H_
 
+#include <string>
+
 #include <sensor_msgs/msg/imu.hpp>
 
 namespace adi_imu
@@ -40,6 +42,12 @@ public:
    * @brief Destructor for ImuDataProviderInterface.
    */
   virtual ~ImuDataProviderInterface() {}
+
+  /**
+   * @brief Set the frame ID for the IMU messages.
+   * @param frame_id The TF frame ID to use for the IMU messages.
+   */
+  virtual void setFrameId(const std::string & frame_id) = 0;
 
   /**
    * @brief Populate Imu message with measured data.

--- a/launch/imu_with_madgwick_filter_rviz.launch.py
+++ b/launch/imu_with_madgwick_filter_rviz.launch.py
@@ -52,12 +52,18 @@ def generate_launch_description():
         description='Whether to enable the publisher of IMU identification data.',
         default_value='false'
     )
+    frame_id_arg = DeclareLaunchArgument(
+        'frame_id',
+        description='The TF frame ID for the IMU sensor (e.g., source_x/imu).',
+        default_value='imu'
+    )
 
     iio_context_string = LaunchConfiguration('iio_context_string')
     imu_device_name = LaunchConfiguration('imu_device_name')
     measured_data_topic_selection = LaunchConfiguration('measured_data_topic_selection')
     diag_data_enable = LaunchConfiguration('diag_data_enable')
     ident_data_enable = LaunchConfiguration('ident_data_enable')
+    frame_id = LaunchConfiguration('frame_id')
 
     rviz_param = launch.substitutions.LaunchConfiguration(
         'rviz_param',
@@ -75,6 +81,7 @@ def generate_launch_description():
             {'measured_data_topic_selection': measured_data_topic_selection},
             {'diag_data_enable': diag_data_enable},
             {'ident_data_enable': ident_data_enable},
+            {'frame_id': frame_id},
         ],
         remappings=[('/imu', '/imu/data_raw')],
         output='screen'
@@ -101,6 +108,7 @@ def generate_launch_description():
         measured_data_topic_selection_arg,
         diag_data_enable_arg,
         ident_data_enable_arg,
+        frame_id_arg,
         adi_imu_node,
         imu_filter_madgwick_node,
         rviz,

--- a/src/imu_data_provider.cpp
+++ b/src/imu_data_provider.cpp
@@ -28,10 +28,7 @@ ImuDataProvider::ImuDataProvider() : m_frame_id("imu") {}
 
 ImuDataProvider::~ImuDataProvider() {}
 
-void ImuDataProvider::setFrameId(const std::string & frame_id)
-{
-  m_frame_id = frame_id;
-}
+void ImuDataProvider::setFrameId(const std::string & frame_id) { m_frame_id = frame_id; }
 
 bool ImuDataProvider::getData(sensor_msgs::msg::Imu & message)
 {

--- a/src/imu_data_provider.cpp
+++ b/src/imu_data_provider.cpp
@@ -24,9 +24,14 @@
 namespace adi_imu
 {
 
-ImuDataProvider::ImuDataProvider() {}
+ImuDataProvider::ImuDataProvider() : m_frame_id("imu") {}
 
 ImuDataProvider::~ImuDataProvider() {}
+
+void ImuDataProvider::setFrameId(const std::string & frame_id)
+{
+  m_frame_id = frame_id;
+}
 
 bool ImuDataProvider::getData(sensor_msgs::msg::Imu & message)
 {
@@ -40,7 +45,7 @@ bool ImuDataProvider::getData(sensor_msgs::msg::Imu & message)
   message.angular_velocity.y = m_iio_wrapper.getBuffAngularVelocityY();
   message.angular_velocity.z = m_iio_wrapper.getBuffAngularVelocityZ();
 
-  message.header.frame_id = "imu";
+  message.header.frame_id = m_frame_id;
   m_iio_wrapper.getBuffSampleTimestamp(message.header.stamp.sec, message.header.stamp.nanosec);
 
   message.orientation_covariance[0] = -1;

--- a/src/imu_ros2_node.cpp
+++ b/src/imu_ros2_node.cpp
@@ -91,6 +91,14 @@ int main(int argc, char * argv[])
   auto ident_data_enable =
     imu_node->get_parameter("ident_data_enable").get_parameter_value().get<bool>();
 
+  auto frame_id_param_desc = rcl_interfaces::msg::ParameterDescriptor{};
+  frame_id_param_desc.description =
+    "\nThe TF frame ID for the IMU sensor (e.g., source_x/imu). Useful when multiple IMUs are used.";
+  imu_node->declare_parameter("frame_id", "imu", frame_id_param_desc);
+
+  auto frame_id =
+    imu_node->get_parameter("frame_id").get_parameter_value().get<std::string>();
+
   /* First make sure IIO context is available */
   std::string context =
     imu_node->get_parameter("iio_context_string").get_parameter_value().get<std::string>();
@@ -113,6 +121,7 @@ int main(int argc, char * argv[])
   accel_gyro_publisher->setMessageProvider(accel_gyro_data_provider);
 
   adi_imu::ImuDataProviderInterface * imu_std_data_provider = new adi_imu::ImuDataProvider();
+  imu_std_data_provider->setFrameId(frame_id);
   adi_imu::ImuRosPublisherInterface * imu_std_publisher = new adi_imu::ImuRosPublisher(imu_node);
   imu_std_publisher->setMessageProvider(imu_std_data_provider);
 

--- a/src/imu_ros2_node.cpp
+++ b/src/imu_ros2_node.cpp
@@ -93,11 +93,11 @@ int main(int argc, char * argv[])
 
   auto frame_id_param_desc = rcl_interfaces::msg::ParameterDescriptor{};
   frame_id_param_desc.description =
-    "\nThe TF frame ID for the IMU sensor (e.g., source_x/imu). Useful when multiple IMUs are used.";
+    "\nThe TF frame ID for the IMU sensor (e.g., source_x/imu). Useful when multiple IMUs are "
+    "used.";
   imu_node->declare_parameter("frame_id", "imu", frame_id_param_desc);
 
-  auto frame_id =
-    imu_node->get_parameter("frame_id").get_parameter_value().get<std::string>();
+  auto frame_id = imu_node->get_parameter("frame_id").get_parameter_value().get<std::string>();
 
   /* First make sure IIO context is available */
   std::string context =


### PR DESCRIPTION
Fix hardcoded frame_id in IMU message header to support multi-robot systems

## Problem
The IMU message header currently uses a hardcoded 'frame_id' value: 
https://github.com/analogdevicesinc/imu_ros2/blob/72a2b80cba4dc0daecc23245b15682c589112ee7/src/imu_data_provider.cpp#L43

This causes issues in two scenarios:
1. **Multiple IMU instances**: When running multiple `adi_imu` nodes in the same network, transforms in the `/tf` topic conflict with each other
2. **Namespaced deployments**: While the IMU topic correctly becomes `/$namespace/imu`, the frame_id remains hardcoded as `imu`, breaking the transform chain

Previously, users had to modify source code and rebuild the package to change the frame_id.

## Solution
This PR makes the frame_id configurable through launch parameters, allowing:
- Dynamic frame_id assignment per IMU instance
- Proper namespace support (e.g., `robot1/imu`, `robot2/imu`)

## Testing
Tested and validated on the AD_R1M system with namespace launch for IMU node.