### PR TITLE
Covariance for IMU data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -527,6 +527,80 @@ frame_id
 The TF frame ID for the IMU sensor (e.g., `source_x/imu`). Useful when multiple
 IMUs are used in the same system to uniquely identify each sensor's data.
 
+IMU covariance parameters
+""""""""""""""""""""""""""
+
+The adi_imu ROS2 node allows for data-driven, IMU noise covariance estimation.
+The following algorithms are available:
+
+* **Static**: Covariances are preset by the user and do not change during IMU operation time.
+* **Welford**: IMU should be static while the node computes covariances using the Welford's algorithm. After the calibration completes, variances are frozen.
+* **Sliding Window**: Maintains a fixed-size buffer of recent samples and continuously recomputes variance over that window. Adapts to changing noise characteristics while the IMU operates.
+* **Exponentially Weighted Moving Average (EWMA)**: Continuously updates variance estimates using exponential smoothing, where recent samples have higher weight. Provides smooth adaptation with O(1) memory usage.
+* **Kalman**: Uses a scalar Kalman filter to estimate variance as a hidden state, treating squared residuals (between current IMU measurement and the estimated mean) as noisy measurements. Provides optimally smoothed, adaptive variance estimates.
+
+To avoid covariance inflation caused by dynamic changes in the measurement mean, a motion detection mechanism is used. 
+Adaptive covariance algorithms (Sliding Window, EWMA, Kalman) only update their estimates when the sensor is stationary. 
+The sensor is considered stationary when:
+
+* Gyroscope magnitude is below gyro_threshold (rad/s)
+* Accelerometer magnitude deviation from gravity is below accel_threshold (m/s²)
+
+During motion, covariance estimates are frozen at their last stationary values.
+
+Parameters which are used in configuring and fine-tunning the covariance estimation are listed in the table below:
+
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|Parameter Name                               |Parameter Description                                                                                                                            |Parameter type  |Default      | 
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.enable                            |Enable/Disable covariance estimation and publishing inside the ROS2 sensor_msgs::msg::Imu **/imu** topic (**measured_data_topic_selection**=2).  |bool            |false        |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.algorithm                         |Desired algorithm used for covariance estimation. Available choices: "static", "welford", "sliding_window", "ewma", "kalman".                    |string          |"welford"    |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.static.accel_variance_x           |Static accelerometer X-axis variance (m/s^2)^2.                                                                                                  |double          |0.01         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.static.accel_variance_y           |Static accelerometer Y-axis variance (m/s^2)^2.                                                                                                  |double          |0.01         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.static.accel_variance_z           |Static accelerometer Z-axis variance (m/s^2)^2.                                                                                                  |double          |0.01         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.static.gyro_variance_x            |Static gyroscope  X-axis variance (rad/s)^2.                                                                                                     |double          |0.001        |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.static.gyro_variance_y            |Static gyroscope  Y-axis variance (rad/s)^2.                                                                                                     |double          |0.001        |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.static.gyro_variance_z            |Static gyroscope  Z-axis variance (rad/s)^2.                                                                                                     |double          |0.001        |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.welford.calibration_samples       |Number of samples used when estimating gyroscope and accelerometer covariances. Value must be > 0.                                               |int             |1000         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.welford.min_variance              |Minimum variance floor for Welford algorithm.                                                                                                    |double          |1e-9         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.sliding_window.window_size        |Number of samples in sliding window. Value must be > 0.                                                                                          |int             |500          |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.sliding_window.min_samples        |Minimum samples before covariance is valid. Value must be > 0.                                                                                   |int             |100          |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.sliding_window.min_variance       |Minimum variance floor for Sliding Window algorithm.                                                                                             |double          |1e-9         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.ewma.alpha                        |EWMA smoothing factor (0 < alpha < 1). Higher = faster adaptation.                                                                               |double          |0.02         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.ewma.warmup_samples               |Warmup samples berfore EWMA covariance is valid. Value must be > 0.                                                                              |int             |100          |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.ewma.min_variance                 |Minimum variance floor for EWMA algorithm.                                                                                                       |double          |1e-9         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.kalman.process_noise_q            |Kalman process noise Q (variance change rate). Larger = more adaptive.                                                                           |double          |1e-6         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.kalman.measurement_noise_r        |Kalman measurement noise R (noise in variance observations).                                                                                     |double          |1e-4         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.kalman.initial_variance           |Initial variance estimate for Kalman filter.                                                                                                     |double          |1e-4         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.kalman.warmup_samples             |Warmup samples before Kalman covariance estimates are valid. Value must be > 0.                                                                  |int             |100          |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.kalman.min_variance               |Minimum variance floor for Kalman filter.                                                                                                        |double          |1e-9         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.motion_detection.enable           |Enable/Disable motion detection for adaptive covariance algorithms. (enable is recommended)                                                      |bool            |true         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.motion_detection.gyro_threshold   |Maximum gyroscope magnitude (rad/s) for stationary detection. Samples with higher angular rates are ignored during covariance estimation.        |double          |0.05         |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
+|covariance.motion_detection.accel_threshold  |Maximum accelerometer magnitude (m/s^2) for stationary detection. Samples with higher values are ignored during covariance estimation.           |double          |0.5          |
++---------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-------------+
 
 IMU parameters
 ^^^^^^^^^^^^^^
@@ -1148,6 +1222,59 @@ EVAL-ADISIMU1-RPIZ using Mounting Slot I with P7 Connector:
         diag_gyroscope2_self_test_error: false
         diag_flash_memory_write_count_exceeded_error: false
         flash_counter: 22
+
+
+Publishing IMU data with covariances
+-------------------------------------
+
+Identify the IP address of the processing unit to which the IMU is connected to
+(e.g. Raspberry Pi) and determine your specific ADIS device name. There are two ways of
+starting publishing IMU + covariance data.
+
+1) Using adi_imu node:
+
+.. code-block:: bash
+
+        ros2 run adi_imu adi_imu_node --ros-args \
+                -p imu_device_name:="adis16545-3" \
+                -p iio_context_string:="ip:192.168.0.1" \
+                -p measured_data_topic_selection:=2 \
+                -p covariance.enable:=true \
+                -p covariance.algorithm:="sliding_window" \
+                -p covariance.sliding_window.window_size:=1500 \
+                -p covariance.sliding_window.min_samples:=300
+
+.. note::
+   Covariance is only published on the **/imu** topic, so ``measured_data_topic_selection`` must be set to 2.
+
+2) Using the imu_and_covariance.launch.py launch file:
+
+imu_ros2 repository offers a launch file to easily start publishing IMU data and 
+measurement variances through imu_and_covariance.launch.py:
+
+.. code-block:: bash
+
+        ros2 launch adi_imu imu_and_covariance.launch.py \
+            iio_context_string:="ip:192.168.0.1" \
+            imu_device_name:="adis16545-3"
+
+The ``config_file`` parameter is optional and defaults to ``config/imu_covariance_config.yaml``.
+To use a custom configuration:
+
+.. code-block:: bash
+
+        ros2 launch adi_imu imu_and_covariance.launch.py \
+            iio_context_string:="ip:192.168.0.1" \
+            imu_device_name:="adis16545-3" \
+            config_file:="/path/to/your/custom_config.yaml"
+
+.. tip::
+    You can see all available launch arguments by running:
+
+    .. code-block:: bash
+
+        ros2 launch adi_imu imu_and_covariance.launch.py --show-args
+
 
 Using adi_imu node with imu-tools
 ----------------------------------

--- a/config/imu_covariance_config.yaml
+++ b/config/imu_covariance_config.yaml
@@ -1,0 +1,40 @@
+/adi_imu_node:
+  ros__parameters:
+    # Core parameters
+    iio_context_string: "ip:192.168.0.1"
+    imu_device_name: "adis16545-3"
+    measured_data_topic_selection: 2
+    
+    # Covariance settings
+    covariance:
+      enable: true
+      algorithm: "kalman"
+      
+      static:
+        accel_variance_x: 0.01
+        accel_variance_y: 0.01
+        accel_variance_z: 0.01
+        gyro_variance_x: 0.001
+        gyro_variance_y: 0.001
+        gyro_variance_z: 0.001
+      
+      welford:
+        calibration_samples: 1000
+        min_variance: 1.0e-9
+      
+      sliding_window:
+        window_size: 500
+        min_samples: 100
+        min_variance: 1.0e-9
+      
+      ewma:
+        alpha: 0.1
+        warmup_samples: 100
+        min_variance: 1.0e-9
+      
+      kalman:
+        process_noise_q: 1.0e-4
+        measurement_noise_r: 1.0e-4
+        initial_variance: 1.0e-4
+        warmup_samples: 100
+        min_variance: 1.0e-9

--- a/config/imu_covariance_config.yaml
+++ b/config/imu_covariance_config.yaml
@@ -1,14 +1,12 @@
 /adi_imu_node:
   ros__parameters:
     # Core parameters
-    iio_context_string: "ip:192.168.0.1"
-    imu_device_name: "adis16545-3"
     measured_data_topic_selection: 2
     
     # Covariance settings
     covariance:
       enable: true
-      algorithm: "kalman"
+      algorithm: "ewma"
       
       static:
         accel_variance_x: 0.01
@@ -38,3 +36,10 @@
         initial_variance: 1.0e-4
         warmup_samples: 100
         min_variance: 1.0e-9
+
+      # Motion detection: only update covariance when sensor is stationary
+      # This prevents motion-induced variance inflation
+      motion_detection:
+        enable: true
+        gyro_threshold: 0.05      # Max angular velocity magnitude (rad/s)
+        accel_threshold: 0.5      # Max deviation from gravity (m/s^2)

--- a/include/adi_imu/ewma_covariance_provider.h
+++ b/include/adi_imu/ewma_covariance_provider.h
@@ -1,0 +1,75 @@
+// Copyright 2025 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ADI_IMU__EWMA_WINDOW_COVARIANCE_PROVIDER_H_
+#define ADI_IMU__EWMA_WINDOW_COVARIANCE_PROVIDER_H_
+
+#include <cstddef>
+
+#include "adi_imu/imu_covariance_interface.h"
+
+namespace adi_imu
+{
+/**
+    * @brief Exponentially Weighted Moving Average covariance estimator.
+    *
+    * Computes variance using exponential smoothing:
+    *  variance_t = alpha * (x_t - mean_t)^2 + (1-alpha) * variance_{t-1}
+    *
+    * Adapts continuously with O(1) memory. Alpha controls responsiveness:
+    * - Higher alpha (0.1): Fast adaptation, more sensitivity
+    * - Lower alpha (0.01): Slow adaptation, smoother estimates
+     */
+
+class EwmaCovarianceProvider : public ImuCovarianceInterface
+{
+public:
+  //Default EWMA covariance estimator parameters
+  inline static constexpr double DEFAULT_ALPHA = 0.02;
+  inline static constexpr size_t DEFAULT_WARMUP_SAMPLES = 100;
+  inline static constexpr double DEFAULT_MIN_VARIANCE = 1e-9;
+
+  /**
+        * @brief Construct EWMA covariance estimator.
+        * @param alpha Smoothing factor (0 < alpha < 1). Typical 0.01-0.1
+        * @param warmup_samples Samples before covariance is considered valid.
+        * @param min_variance Minimum variance floor.
+        */
+
+  explicit EwmaCovarianceProvider(
+    double alpha = DEFAULT_ALPHA, size_t warmup_samples = DEFAULT_WARMUP_SAMPLES,
+    double min_variance = DEFAULT_MIN_VARIANCE);
+
+  void addSample(const Vec3 & accel, const Vec3 & gyro) override;
+  bool isReady() const override;
+  CovarianceMatrix getAccelCovariance() const override;
+  CovarianceMatrix getGyroCovariance() const override;
+  void reset() override;
+  double getCalibrationProgress() const override;
+
+private:
+  double m_alpha;
+  size_t m_warmup_samples;
+  size_t m_sample_count;
+  double m_min_variance;
+
+  //EWMA state (mean and variance for each axis)
+  Vec3 m_accel_mean;
+  Vec3 m_accel_var;
+  Vec3 m_gyro_mean;
+  Vec3 m_gyro_var;
+};
+}  // namespace adi_imu
+
+#endif  // ADI_IMU__EWMA_WINDOW_COVARIANCE_PROVIDER_H_

--- a/include/adi_imu/ewma_covariance_provider.h
+++ b/include/adi_imu/ewma_covariance_provider.h
@@ -18,6 +18,7 @@
 #include <cstddef>
 
 #include "adi_imu/imu_covariance_interface.h"
+#include "adi_imu/motion_detector.h"
 
 namespace adi_imu
 {
@@ -35,21 +36,21 @@ namespace adi_imu
 class EwmaCovarianceProvider : public ImuCovarianceInterface
 {
 public:
-  //Default EWMA covariance estimator parameters
+  // Default EWMA covariance estimator parameters
   inline static constexpr double DEFAULT_ALPHA = 0.02;
   inline static constexpr size_t DEFAULT_WARMUP_SAMPLES = 100;
   inline static constexpr double DEFAULT_MIN_VARIANCE = 1e-9;
 
   /**
-        * @brief Construct EWMA covariance estimator.
-        * @param alpha Smoothing factor (0 < alpha < 1). Typical 0.01-0.1
-        * @param warmup_samples Samples before covariance is considered valid.
-        * @param min_variance Minimum variance floor.
-        */
-
+   * @brief Construct EWMA covariance estimator.
+   * @param alpha Smoothing factor (0 < alpha < 1). Typical 0.01-0.1
+   * @param warmup_samples Samples before covariance is considered valid.
+   * @param min_variance Minimum variance floor.
+   * @param motion_detector Optional motion detector for stationary filtering.
+   */
   explicit EwmaCovarianceProvider(
     double alpha = DEFAULT_ALPHA, size_t warmup_samples = DEFAULT_WARMUP_SAMPLES,
-    double min_variance = DEFAULT_MIN_VARIANCE);
+    double min_variance = DEFAULT_MIN_VARIANCE, MotionDetector motion_detector = MotionDetector());
 
   void addSample(const Vec3 & accel, const Vec3 & gyro) override;
   bool isReady() const override;
@@ -64,7 +65,10 @@ private:
   size_t m_sample_count;
   double m_min_variance;
 
-  //EWMA state (mean and variance for each axis)
+  // Motion detector for stationary filtering
+  MotionDetector m_motion_detector;
+
+  // EWMA state (mean and variance for each axis)
   Vec3 m_accel_mean;
   Vec3 m_accel_var;
   Vec3 m_gyro_mean;

--- a/include/adi_imu/imu_covariance_factory.h
+++ b/include/adi_imu/imu_covariance_factory.h
@@ -1,0 +1,70 @@
+// Copyright 2025 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ADI_IMU__IMU_COVARIANCE_FACTORY_H_
+#define ADI_IMU__IMU_COVARIANCE_FACTORY_H_
+
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <string>
+
+#include "adi_imu/imu_covariance_interface.h"
+
+namespace adi_imu
+{
+/**
+    * @brief Covariance computation algorithm types.
+     */
+
+enum class CovarianceAlgorithm
+{
+  STATIC,          // Fixed values from parameters
+  WELFORD_ONLINE,  // Calibration-based (Welford's algorithm)
+  SLIDING_WINDOW,  // Adaptive sliding window
+  EWMA,            // Exponentially-Weighted Moving Average (EWMA)
+  KALMAN,          // Kalman filter-based variance estimation
+};
+
+/**
+     * @brief Factory for creating covariance providers based on configuration.
+      */
+class ImuCovarianceFactory
+{
+public:
+  /**
+            * @brief Create a covariance provider from ROS2 parameters.
+            * @param node ROS2 node for parameter access.
+            * @return Unique pointer to covariance provider, or nullptr if disabled
+             */
+  static std::unique_ptr<ImuCovarianceInterface> createFromParameters(
+    const std::shared_ptr<rclcpp::Node> & node);
+
+  /**
+            * @brief Create a covariance provider by algorithm type.
+            * @param params Algorithm-specific parameters.
+            * @return Unique pointer to covariance provider.
+             */
+  static std::unique_ptr<ImuCovarianceInterface> create(
+    CovarianceAlgorithm algorithm, const std::shared_ptr<rclcpp::Node> & node);
+
+  /**
+            * @brief Parse algorithm type from string
+            * @param algorithm_str String representation ("static, welford", "sliding_window", "ewma", "kalman").
+            * @return Corresponding enum value.
+             */
+  static CovarianceAlgorithm parseAlgorithm(const std::string & algorithm_str);
+};
+}  // namespace adi_imu
+
+#endif  // ADI_IMU__IMU_COVARIANCE_FACTORY_H_

--- a/include/adi_imu/imu_covariance_interface.h
+++ b/include/adi_imu/imu_covariance_interface.h
@@ -1,0 +1,90 @@
+// Copyright 2025 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ADI_IMU__IMU_COVARIANCE_INTERFACE_H_
+#define ADI_IMU__IMU_COVARIANCE_INTERFACE_H_
+
+#include <array>
+#include <geometry_msgs/msg/vector3.hpp>
+
+namespace adi_imu
+{
+/**
+    * @brief 3x3 covariance matrix stored as row-major array
+    * Layout: [xx ,xy, xz, yx, yy, yz, zx, zy, zz]
+     */
+using CovarianceMatrix = std::array<double, 9>;
+
+/**
+     * @brief 3D vector for acceleration or angular velocity samples using ROS2 built-in geometry_msgs::msg::Vector3 interface.
+    */
+using Vec3 = geometry_msgs::msg::Vector3;
+
+/**
+      * @brief Interface for IMU covariance computation strategies.
+      *
+      * Implementation can provide static covariance values, compute them 
+      * online during a calibration phase, or adapt them continuously
+       */
+
+class ImuCovarianceInterface
+{
+public:
+  ImuCovarianceInterface() = default;
+  virtual ~ImuCovarianceInterface() = default;
+
+  // Prevent copying
+  ImuCovarianceInterface(const ImuCovarianceInterface &) = delete;
+  ImuCovarianceInterface & operator=(const ImuCovarianceInterface &) = delete;
+
+  /**
+            * @brief Process a new IMU sample for covariance estimation.
+            * @param accel Linear acceleration sample (m/s^2)
+            * @param gyro Angular velocity sample (rad/s)
+            */
+  virtual void addSample(const Vec3 & accel, const Vec3 & gyro) = 0;
+
+  /**
+            * @brief Check if covariance estimation is ready (calibration complete).
+            * @return true if covariance values are valid and ready to use.
+             */
+  virtual bool isReady() const = 0;
+
+  /**
+            * @brief Get the linear acceleration covariance matrix.
+            * @return 3x3 covariance matrix row-major order.
+            */
+  virtual CovarianceMatrix getAccelCovariance() const = 0;
+
+  /**
+            * @brief Get the angular velocity covariance matrix.
+            * @return 3x3 covariance matrix row-major order.
+            */
+  virtual CovarianceMatrix getGyroCovariance() const = 0;
+
+  /**
+            * @brief Reset the covariance extimator to initial state.
+            */
+  virtual void reset() = 0;
+
+  /**
+            * @brief Get the current calibration progress (0.0 to 1.0).
+            * @return Progress ratio, 1.0 when calibration is complete.
+             */
+  virtual double getCalibrationProgress() const = 0;
+};
+
+}  // namespace adi_imu
+
+#endif  // ADI_IMU__IMU_COVARIANCE_INTERFACE_H_

--- a/include/adi_imu/imu_data_provider.h
+++ b/include/adi_imu/imu_data_provider.h
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "adi_imu/iio_wrapper.h"
+#include "adi_imu/imu_covariance_interface.h"  // Publish covariances
 #include "adi_imu/imu_data_provider_interface.h"
 
 namespace adi_imu
@@ -58,12 +59,21 @@ public:
    */
   bool getData(sensor_msgs::msg::Imu & message) override;
 
+  /**
+  * @brief Set the covariance provider for IMU messages.
+  * @param provider Pointer to covariance provider (ownership not transferred).
+   */
+  void setCovarianceProvider(ImuCovarianceInterface * provider) override;
+
 private:
   /*! This data member is used to access sensor information via libiio. */
   IIOWrapper m_iio_wrapper;
 
   /*! The TF frame ID for the IMU sensor. */
   std::string m_frame_id;
+
+  /*! Optional covariance provider for populating covariance matrices. */
+  ImuCovarianceInterface * m_covariance_provider = nullptr;
 };
 
 }  // namespace adi_imu

--- a/include/adi_imu/imu_data_provider_interface.h
+++ b/include/adi_imu/imu_data_provider_interface.h
@@ -26,6 +26,9 @@
 namespace adi_imu
 {
 
+// Forward declaration of covariance interface
+class ImuCovarianceInterface;
+
 /**
  * @brief Interface for standard message sensor_msgs::msg::Imu data provider.
  */
@@ -55,6 +58,12 @@ public:
    * measured data and false otherwise.
    */
   virtual bool getData(sensor_msgs::msg::Imu & message) = 0;
+
+  /**
+  * @brief Method to set the desired covariance algorithm
+  * @param provider The provider can be an instance of: Static, Welford or SlidingWindow providers
+   */
+  virtual void setCovarianceProvider(ImuCovarianceInterface * provider) = 0;
 };
 
 }  // namespace adi_imu

--- a/include/adi_imu/kalman_covariance_provider.h
+++ b/include/adi_imu/kalman_covariance_provider.h
@@ -23,6 +23,7 @@
 #include <cstddef>
 
 #include "adi_imu/imu_covariance_interface.h"
+#include "adi_imu/motion_detector.h"
 
 namespace adi_imu
 {
@@ -67,12 +68,14 @@ public:
    * @param initial_variance Initial variance estimate for all axes
    * @param warmup_samples Number of samples before estimates are valid
    * @param min_variance Minimum variance floor
+   * @param motion_detector Optional motion detector for stationary filtering
    */
   KalmanCovarianceProvider(
     double process_noise_q = DEFAULT_PROCESS_NOISE_Q,
     double measurement_noise_r = DEFAULT_MEASUREMENT_NOISE_R,
     double initial_variance = DEFAULT_INITIAL_VARIANCE,
-    size_t warmup_samples = DEFAULT_WARMUP_SAMPLES, double min_variance = DEFAULT_MIN_VARIANCE);
+    size_t warmup_samples = DEFAULT_WARMUP_SAMPLES, double min_variance = DEFAULT_MIN_VARIANCE,
+    MotionDetector motion_detector = MotionDetector());
 
   ~KalmanCovarianceProvider() override = default;
 
@@ -117,6 +120,9 @@ private:
   double m_measurement_noise_r;  // R: measurement noise covariance
   double m_initial_variance;     // Initial variance estimate
   double m_min_variance;         // Minimum variance floor
+
+  // Motion detector for stationary filtering
+  MotionDetector m_motion_detector;
 
   // Per-axis filters
   AxisFilter m_accel_x;

--- a/include/adi_imu/kalman_covariance_provider.h
+++ b/include/adi_imu/kalman_covariance_provider.h
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ *   @file   kalman_covariance_provider.h
+ *   @brief  Kalman filter-based covariance estimation for IMU data.
+ *   @author Tudor Alinei
+ *******************************************************************************/
+// Copyright 2026 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ADI_IMU__KALMAN_COVARIANCE_PROVIDER_H_
+#define ADI_IMU__KALMAN_COVARIANCE_PROVIDER_H_
+
+#include <cstddef>
+
+#include "adi_imu/imu_covariance_interface.h"
+
+namespace adi_imu
+{
+
+/**
+ * @brief Kalman filter-based covariance estimator for IMU data.
+ *
+ * This provider uses a scalar Kalman filter for each axis to estimate
+ * the measurement variance. The approach treats variance as a slowly-varying
+ * state and uses squared residuals from the running mean as noisy measurements
+ * of the true variance.
+ *
+ * State model: variance_k = variance_{k-1} + w_k, where w_k ~ N(0, Q)
+ * Measurement model: z_k = variance_k + v_k, where v_k ~ N(0, R)
+ * True variance measurement: y_k = (sample - mean)^2
+ *
+ * The filter provides adaptive, smoothed variance estimates that respond
+ * to changes in sensor noise characteristics while filtering out spurious
+ * variations.
+ *
+ * Parameters:
+ * - process_noise_q: How fast the variance can change (larger = more adaptive)
+ * - measurement_noise_r: How noisy our variance observations are
+ * - initial_variance: Starting estimate for variance
+ * - warmup_samples: Samples needed before estimates are considered valid
+ * - min_variance: Minimum variance floor to prevent numerical issues
+ */
+class KalmanCovarianceProvider : public ImuCovarianceInterface
+{
+public:
+  // Default Kalman filter covariance algorithm parameters
+  inline static constexpr double DEFAULT_PROCESS_NOISE_Q = 1e-6;
+  inline static constexpr double DEFAULT_MEASUREMENT_NOISE_R = 1e-4;
+  inline static constexpr double DEFAULT_INITIAL_VARIANCE = 1e-4;
+  inline static constexpr size_t DEFAULT_WARMUP_SAMPLES = 100;
+  inline static constexpr double DEFAULT_MIN_VARIANCE = 1e-9;
+
+  /**
+   * @brief Construct a Kalman filter covariance provider.
+   * @param process_noise_q Process noise covariance (variance change rate)
+   * @param measurement_noise_r Measurement noise covariance
+   * @param initial_variance Initial variance estimate for all axes
+   * @param warmup_samples Number of samples before estimates are valid
+   * @param min_variance Minimum variance floor
+   */
+  KalmanCovarianceProvider(
+    double process_noise_q = DEFAULT_PROCESS_NOISE_Q,
+    double measurement_noise_r = DEFAULT_MEASUREMENT_NOISE_R,
+    double initial_variance = DEFAULT_INITIAL_VARIANCE,
+    size_t warmup_samples = DEFAULT_WARMUP_SAMPLES, double min_variance = DEFAULT_MIN_VARIANCE);
+
+  ~KalmanCovarianceProvider() override = default;
+
+  void addSample(const Vec3 & accel, const Vec3 & gyro) override;
+  bool isReady() const override;
+  CovarianceMatrix getAccelCovariance() const override;
+  CovarianceMatrix getGyroCovariance() const override;
+  void reset() override;
+  double getCalibrationProgress() const override;
+
+private:
+  /**
+   * @brief Per-axis Kalman filter state for variance estimation.
+   */
+  struct AxisFilter
+  {
+    double mean;              // Running mean estimate
+    double variance;          // Kalman state: estimated variance
+    double error_covariance;  // Kalman error covariance (P)
+
+    AxisFilter() : mean(0.0), variance(0.0), error_covariance(1.0) {}
+  };
+
+  /**
+   * @brief Update a single axis filter with a new sample.
+   * @param filter The axis filter to update
+   * @param sample The new measurement
+   */
+  void updateAxisFilter(AxisFilter & filter, double sample);
+
+  /**
+   * @brief Build diagonal covariance matrix from axis variances.
+   * @param var_x Variance for x-axis
+   * @param var_y Variance for y-axis
+   * @param var_z Variance for z-axis
+   * @return 3x3 diagonal covariance matrix
+   */
+  CovarianceMatrix buildCovarianceMatrix(double var_x, double var_y, double var_z) const;
+
+  // Kalman filter parameters
+  double m_process_noise_q;      // Q: process noise covariance
+  double m_measurement_noise_r;  // R: measurement noise covariance
+  double m_initial_variance;     // Initial variance estimate
+  double m_min_variance;         // Minimum variance floor
+
+  // Per-axis filters
+  AxisFilter m_accel_x;
+  AxisFilter m_accel_y;
+  AxisFilter m_accel_z;
+  AxisFilter m_gyro_x;
+  AxisFilter m_gyro_y;
+  AxisFilter m_gyro_z;
+
+  // Sample tracking
+  size_t m_warmup_samples;
+  size_t m_sample_count;
+
+  // Mean estimation parameters (for computing residuals)
+  static constexpr double MEAN_ALPHA = 0.01;  // EMA factor for mean tracking
+};
+
+}  // namespace adi_imu
+
+#endif  // ADI_IMU__KALMAN_COVARIANCE_PROVIDER_H_

--- a/include/adi_imu/motion_detector.h
+++ b/include/adi_imu/motion_detector.h
@@ -1,0 +1,102 @@
+// Copyright 2026 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ADI_IMU__MOTION_DETECTOR_H_
+#define ADI_IMU__MOTION_DETECTOR_H_
+
+#include <cmath>
+
+#include "adi_imu/imu_covariance_interface.h"
+
+namespace adi_imu
+{
+
+/**
+ * @brief Detects whether the IMU is stationary based on sensor readings.
+ *
+ * Uses simple thresholding on gyroscope magnitude and accelerometer deviation
+ * from gravity to determine stationarity. This allows covariance estimators
+ * to only update during stationary periods, avoiding motion-induced variance
+ * inflation.
+ */
+class MotionDetector
+{
+public:
+  // Default thresholds for stationarity detection
+  // Gyro threshold: max angular velocity magnitude (rad/s)
+  inline static constexpr double DEFAULT_GYRO_THRESHOLD = 0.05;
+  // Accel threshold: max deviation from gravity magnitude (m/s^2)
+  inline static constexpr double DEFAULT_ACCEL_THRESHOLD = 0.5;
+  // Expected gravity magnitude (m/s^2)
+  inline static constexpr double GRAVITY_MAGNITUDE = 9.81;
+
+  /**
+   * @brief Construct motion detector with configurable thresholds.
+   * @param gyro_threshold Max gyro magnitude to consider stationary (rad/s)
+   * @param accel_threshold Max accel deviation from gravity (m/s^2)
+   */
+  explicit MotionDetector(
+    double gyro_threshold = DEFAULT_GYRO_THRESHOLD,
+    double accel_threshold = DEFAULT_ACCEL_THRESHOLD);
+
+  /**
+   * @brief Check if the sensor is stationary based on current readings.
+   * @param accel Linear acceleration sample (m/s^2)
+   * @param gyro Angular velocity sample (rad/s)
+   * @return true if sensor appears stationary
+   */
+  bool isStationary(const Vec3 & accel, const Vec3 & gyro) const;
+
+  /**
+   * @brief Set the gyroscope threshold for stationarity.
+   * @param threshold Max angular velocity magnitude (rad/s)
+   */
+  void setGyroThreshold(double threshold);
+
+  /**
+   * @brief Set the accelerometer threshold for stationarity.
+   * @param threshold Max deviation from gravity (m/s^2)
+   */
+  void setAccelThreshold(double threshold);
+
+  /**
+   * @brief Get current gyroscope threshold.
+   */
+  double getGyroThreshold() const { return m_gyro_threshold; }
+
+  /**
+   * @brief Get current accelerometer threshold.
+   */
+  double getAccelThreshold() const { return m_accel_threshold; }
+
+  /**
+   * @brief Enable or disable motion detection.
+   * When disabled, isStationary() always returns true.
+   */
+  void setEnabled(bool enabled) { m_enabled = enabled; }
+
+  /**
+   * @brief Check if motion detection is enabled.
+   */
+  bool isEnabled() const { return m_enabled; }
+
+private:
+  double m_gyro_threshold;
+  double m_accel_threshold;
+  bool m_enabled;
+};
+
+}  // namespace adi_imu
+
+#endif  // ADI_IMU__MOTION_DETECTOR_H_

--- a/include/adi_imu/sliding_window_covariance_provider.h
+++ b/include/adi_imu/sliding_window_covariance_provider.h
@@ -1,0 +1,83 @@
+// Copyright 2025 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ADI_IMU__SLIDING_WINDOW_COVARIANCE_PROVIDER_H_
+#define ADI_IMU__SLIDING_WINDOW_COVARIANCE_PROVIDER_H_
+
+#include <cstddef>
+#include <deque>
+
+#include "adi_imu/imu_covariance_interface.h"
+
+namespace adi_imu
+{
+/**
+    * @brief Computes covariances over a sliding window of recent samples.
+    *
+    * This provider maintains a fixed-size window of samples and continuously
+    * updates the covariance estimate. Useful for adaptive covariance that 
+    * responds to changing sensor noise characteristics.
+     */
+
+class SlidingWindowCovarianceProvider : public ImuCovarianceInterface
+{
+public:
+  /**
+            * @brief Default Sliding-window covariance algorithm parameters
+             */
+  inline static constexpr size_t DEFAULT_WINDOW_SIZE = 500;
+  inline static constexpr size_t DEFAULT_MIN_SAMPLES = 100;
+  inline static constexpr double DEFAULT_MIN_VARIANCE = 1e-9;
+
+  /**
+            * @brief Construct sliding window covariance estimator.
+            * @param window_size Number of samples to keep in window.
+            * @param min_samples Minimum samples befor covariance is valid.
+            * @param min_variance Minimum variance floor.
+             */
+
+  explicit SlidingWindowCovarianceProvider(
+    size_t window_size = DEFAULT_WINDOW_SIZE, size_t min_samples = DEFAULT_MIN_SAMPLES,
+    double min_variance = DEFAULT_MIN_VARIANCE);
+
+  void addSample(const Vec3 & accel, const Vec3 & gyro) override;
+  bool isReady() const override;
+  CovarianceMatrix getAccelCovariance() const override;
+  CovarianceMatrix getGyroCovariance() const override;
+  void reset() override;
+  double getCalibrationProgress() const override;
+
+private:
+  void recomputeCovariance();
+  double computeVariance(const std::deque<double> & samples, double mean) const;
+
+  size_t m_window_size;
+  size_t m_min_samples;
+  double m_min_variance;
+
+  // Circular buffers for samples
+  std::deque<Vec3> m_accel_samples;
+  std::deque<Vec3> m_gyro_samples;
+
+  // Cached covariance (periodically recomputed)
+  CovarianceMatrix m_accel_covariance;
+  CovarianceMatrix m_gyro_covariance;
+
+  //Recompute every N samples for efficiency
+  size_t m_update_interval;
+  size_t m_samples_since_update;
+};
+}  // namespace adi_imu
+
+#endif  // ADI_IMU__SLIDING_WINDOW_PROVIDER_H_

--- a/include/adi_imu/sliding_window_covariance_provider.h
+++ b/include/adi_imu/sliding_window_covariance_provider.h
@@ -19,6 +19,7 @@
 #include <deque>
 
 #include "adi_imu/imu_covariance_interface.h"
+#include "adi_imu/motion_detector.h"
 
 namespace adi_imu
 {
@@ -41,15 +42,15 @@ public:
   inline static constexpr double DEFAULT_MIN_VARIANCE = 1e-9;
 
   /**
-            * @brief Construct sliding window covariance estimator.
-            * @param window_size Number of samples to keep in window.
-            * @param min_samples Minimum samples befor covariance is valid.
-            * @param min_variance Minimum variance floor.
-             */
-
+   * @brief Construct sliding window covariance estimator.
+   * @param window_size Number of samples to keep in window.
+   * @param min_samples Minimum samples before covariance is valid.
+   * @param min_variance Minimum variance floor.
+   * @param motion_detector Optional motion detector for stationary filtering.
+   */
   explicit SlidingWindowCovarianceProvider(
     size_t window_size = DEFAULT_WINDOW_SIZE, size_t min_samples = DEFAULT_MIN_SAMPLES,
-    double min_variance = DEFAULT_MIN_VARIANCE);
+    double min_variance = DEFAULT_MIN_VARIANCE, MotionDetector motion_detector = MotionDetector());
 
   void addSample(const Vec3 & accel, const Vec3 & gyro) override;
   bool isReady() const override;
@@ -60,11 +61,13 @@ public:
 
 private:
   void recomputeCovariance();
-  double computeVariance(const std::deque<double> & samples, double mean) const;
 
   size_t m_window_size;
   size_t m_min_samples;
   double m_min_variance;
+
+  // Motion detector for stationary filtering
+  MotionDetector m_motion_detector;
 
   // Circular buffers for samples
   std::deque<Vec3> m_accel_samples;
@@ -74,10 +77,10 @@ private:
   CovarianceMatrix m_accel_covariance;
   CovarianceMatrix m_gyro_covariance;
 
-  //Recompute every N samples for efficiency
+  // Recompute every N samples for efficiency
   size_t m_update_interval;
   size_t m_samples_since_update;
 };
 }  // namespace adi_imu
 
-#endif  // ADI_IMU__SLIDING_WINDOW_PROVIDER_H_
+#endif  // ADI_IMU__SLIDING_WINDOW_COVARIANCE_PROVIDER_H_

--- a/include/adi_imu/static_covariance_provider.h
+++ b/include/adi_imu/static_covariance_provider.h
@@ -1,0 +1,64 @@
+// Copyright 2025 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ADI_IMU__STATIC_COVARIANCE_PROVIDER_H_
+#define ADI_IMU__STATIC_COVARIANCE_PROVIDER_H_
+
+#include "adi_imu/imu_covariance_interface.h"
+
+namespace adi_imu
+{
+
+/**
+    * @brief Provides fixed/static covariance values from configuration.
+    * Use this when covariance values are known from datasheet specifications
+    * or prior calibration. No runtime computatino is performed.
+     */
+
+class StaticCovarianceProvider : public ImuCovarianceInterface
+{
+public:
+  // Default static covariance values
+  inline static constexpr double DEFAULT_STATIC_ACCEL_COVARIANCE = 0.01;
+  inline static constexpr double DEFAULT_STATIC_GYRO_COVARIANCE = 0.001;
+
+  /**
+        * @brief Construct diagonal covariance values. Measurements are not intercorrelated.
+        * @param accel_variance Variance for each accelerometer axis (m/s^2)^2
+        * @param gyro_variance Variance for each gyroscope axis (rad/s)^2.
+         */
+  StaticCovarianceProvider(const Vec3 & accel_variance, const Vec3 & gyro_variance);
+
+  /**
+        * @brief Construct with full covariance matrices.
+        * @param accel_cov Full 3x3 accelerometer covariance matrix
+        * @param gyro_cov Full 3x3 gyroscope covariance matrix
+         */
+  StaticCovarianceProvider(const CovarianceMatrix & accel_cov, const CovarianceMatrix & gyro_cov);
+
+  void addSample(const Vec3 & accel, const Vec3 & gyro) override;
+  bool isReady() const override;
+  CovarianceMatrix getAccelCovariance() const override;
+  CovarianceMatrix getGyroCovariance() const override;
+  void reset() override;
+  double getCalibrationProgress() const override;
+
+private:
+  CovarianceMatrix m_accel_covariance;
+  CovarianceMatrix m_gyro_covariance;
+};
+
+}  // namespace adi_imu
+
+#endif  // ADI_IMU__STATIC_COVARIANCE_PROVIDER_H_

--- a/include/adi_imu/welford_covariance_provider.h
+++ b/include/adi_imu/welford_covariance_provider.h
@@ -1,0 +1,77 @@
+// Copyright 2025 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ADI_IMU__WELFORD_COVARIANCE_PROVIDER_H_
+#define ADI_IMU__WELFORD_COVARIANCE_PROVIDER_H_
+
+#include <cstddef>
+
+#include "adi_imu/imu_covariance_interface.h"
+
+namespace adi_imu
+{
+
+/**
+        * @brief Computes covariance online using Welford's algorithm.
+        *
+        * This provider collects samples during the calibration phrase (IMU should 
+        * be stationary) and computes variance using Welford's numerically stable
+        * online algorithm. After calibration_samples are collected, the covariance
+        * is frozen and returned for all subsequent queries.
+        *
+        * Reference: Welford, B. P. (1962). "Note on method for calculating
+        * corrected sum of squares and products"
+        */
+class WelfordCovarianceProvider : public ImuCovarianceInterface
+{
+public:
+  //Default Welford algorithm parameters
+  inline static constexpr size_t DEFAULT_CALIBRATION_SAMPLES = 1000;
+  inline static constexpr double DEFAULT_MIN_VARIANCE = 1e-9;
+
+  explicit WelfordCovarianceProvider(
+    size_t calibration_samples = DEFAULT_CALIBRATION_SAMPLES,
+    double min_variance = DEFAULT_MIN_VARIANCE);
+
+  void addSample(const Vec3 & accel, const Vec3 & gyro) override;
+  bool isReady() const override;
+  CovarianceMatrix getAccelCovariance() const override;
+  CovarianceMatrix getGyroCovariance() const override;
+  void reset() override;
+  double getCalibrationProgress() const override;
+
+private:
+  void updateWelford(double value, double & mean, double & M2, size_t n);
+  double computeVariance(double M2, size_t n) const;
+
+  size_t m_target_samples;
+  size_t m_sample_count;
+  double m_min_variance;
+
+  // Welford state for accelerometer (mean and M2 for each axis)
+  Vec3 m_accel_mean;
+  Vec3 m_accel_M2;
+
+  // Welford state for gyro
+  Vec3 m_gyro_mean;
+  Vec3 m_gyro_M2;
+
+  // Frozen covariance after calibration
+  CovarianceMatrix m_accel_covariance;
+  CovarianceMatrix m_gyro_covariance;
+  bool m_calibration_complete;
+};
+}  // namespace adi_imu
+
+#endif  // ADI_IMU__WELFORD_COVARIANCE_PROVIDER_H_

--- a/launch/imu_and_covariance.launch.py
+++ b/launch/imu_and_covariance.launch.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Analog Devices, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import launch
+import launch_ros.actions
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    # Get config file path
+    config_file_arg = DeclareLaunchArgument(
+        'config_file',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('adi_imu'),
+            'config',
+            'imu_covariance_config.yaml'
+        ]),
+        description='Path to the YAML configuration file'
+    )
+    
+    config_file = LaunchConfiguration('config_file')
+    
+    # Keep required args without defaults (user must provide)
+    iio_context_string_arg = DeclareLaunchArgument(
+        'iio_context_string',
+        description='The URI of the IMU (e.g: ip:192.168.2.1).',
+    )
+    imu_device_name_arg = DeclareLaunchArgument(
+        'imu_device_name', 
+        description='IMU device name (e.g., adis16545-3).',
+    )
+    
+    adi_imu_node = launch_ros.actions.Node(
+        package='adi_imu',
+        executable='adi_imu_node',
+        parameters=[
+            config_file,  # Load YAML config first
+            {'iio_context_string': LaunchConfiguration('iio_context_string')},
+            {'imu_device_name': LaunchConfiguration('imu_device_name')},
+        ],
+        remappings=[('/imu', '/imu/data_raw')],
+        output='screen'
+    )
+    
+    return launch.LaunchDescription([
+        config_file_arg,
+        iio_context_string_arg,
+        imu_device_name_arg,
+        adi_imu_node,
+    ])

--- a/src/ewma_covariance_provider.cpp
+++ b/src/ewma_covariance_provider.cpp
@@ -1,0 +1,115 @@
+// Copyright 2026 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "adi_imu/ewma_covariance_provider.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace adi_imu
+{
+EwmaCovarianceProvider::EwmaCovarianceProvider(
+  double alpha, size_t warmup_samples, double min_variance)
+: m_alpha(alpha),
+  m_warmup_samples(warmup_samples),
+  m_sample_count(0),
+  m_min_variance(min_variance),
+  m_accel_mean{0.0, 0.0, 0.0},
+  m_accel_var{0.0, 0.0, 0.0},
+  m_gyro_mean{0.0, 0.0, 0.0},
+  m_gyro_var{0.0, 0.0, 0.0}
+{
+}
+
+void EwmaCovarianceProvider::addSample(const Vec3 & accel, const Vec3 & gyro)
+{
+  // Guard against NaN from sensor
+  if (
+    std::isnan(accel.x) || std::isnan(accel.y) || std::isnan(accel.z) || std::isnan(gyro.x) ||
+    std::isnan(gyro.y) || std::isnan(gyro.z)) {
+    return;
+  }
+  // Only increment until warmup completes - prevents overflow
+  if (m_sample_count < m_warmup_samples) {
+    m_sample_count++;
+  }
+
+  if (m_sample_count == 1) {
+    //Initialize with first sample
+    m_accel_mean = accel;
+    m_gyro_mean = gyro;
+    return;
+  }
+
+  //EWMA mean update : mean_t = alpha * x_t + (1-alpha) * mean_{t-1}
+  auto updateMean = [this](double x, double & mean) {
+    mean = m_alpha * x + (1.0 - m_alpha) * mean;
+  };
+
+  //EWMA variance update: var_t = alpha * (x_t - mean_t)^2 + (1-alpha) * var_{t-1}
+  auto updateVar = [this](double x, double mean, double & var) {
+    double diff = x - mean;
+    var = m_alpha * (diff * diff) + (1.0 - m_alpha) * var;
+  };
+
+  // Update accelerometer
+  updateVar(accel.x, m_accel_mean.x, m_accel_var.x);
+  updateVar(accel.y, m_accel_mean.y, m_accel_var.y);
+  updateVar(accel.z, m_accel_mean.z, m_accel_var.z);
+  updateMean(accel.x, m_accel_mean.x);
+  updateMean(accel.y, m_accel_mean.y);
+  updateMean(accel.z, m_accel_mean.z);
+
+  // Update gyroscope
+  updateVar(gyro.x, m_gyro_mean.x, m_gyro_var.x);
+  updateVar(gyro.y, m_gyro_mean.y, m_gyro_var.y);
+  updateVar(gyro.z, m_gyro_mean.z, m_gyro_var.z);
+  updateMean(gyro.x, m_gyro_mean.x);
+  updateMean(gyro.y, m_gyro_mean.y);
+  updateMean(gyro.z, m_gyro_mean.z);
+}
+
+bool EwmaCovarianceProvider::isReady() const { return m_sample_count >= m_warmup_samples; }
+
+CovarianceMatrix EwmaCovarianceProvider::getAccelCovariance() const
+{
+  return {std::max(m_accel_var.x, m_min_variance), 0.0, 0.0, 0.0,
+          std::max(m_accel_var.y, m_min_variance), 0.0, 0.0, 0.0,
+          std::max(m_accel_var.z, m_min_variance)};
+}
+
+CovarianceMatrix EwmaCovarianceProvider::getGyroCovariance() const
+{
+  return {std::max(m_gyro_var.x, m_min_variance), 0.0, 0.0, 0.0,
+          std::max(m_gyro_var.y, m_min_variance), 0.0, 0.0, 0.0,
+          std::max(m_gyro_var.z, m_min_variance)};
+}
+
+void EwmaCovarianceProvider::reset()
+{
+  m_sample_count = 0;
+  m_accel_mean = {0.0, 0.0, 0.0};
+  m_accel_var = {0.0, 0.0, 0.0};
+  m_gyro_mean = {0.0, 0.0, 0.0};
+  m_gyro_var = {0.0, 0.0, 0.0};
+}
+
+double EwmaCovarianceProvider::getCalibrationProgress() const
+{
+  if (m_sample_count >= m_warmup_samples) {
+    return 1.0;
+  }
+  return static_cast<double>(m_sample_count) / static_cast<double>(m_warmup_samples);
+}
+}  // namespace adi_imu

--- a/src/ewma_covariance_provider.cpp
+++ b/src/ewma_covariance_provider.cpp
@@ -16,19 +16,21 @@
 
 #include <algorithm>
 #include <cmath>
+#include <utility>
 
 namespace adi_imu
 {
 EwmaCovarianceProvider::EwmaCovarianceProvider(
-  double alpha, size_t warmup_samples, double min_variance)
+  double alpha, size_t warmup_samples, double min_variance, MotionDetector motion_detector)
 : m_alpha(alpha),
   m_warmup_samples(warmup_samples),
   m_sample_count(0),
   m_min_variance(min_variance),
-  m_accel_mean{0.0, 0.0, 0.0},
-  m_accel_var{0.0, 0.0, 0.0},
-  m_gyro_mean{0.0, 0.0, 0.0},
-  m_gyro_var{0.0, 0.0, 0.0}
+  m_motion_detector(std::move(motion_detector)),
+  m_accel_mean{},
+  m_accel_var{},
+  m_gyro_mean{},
+  m_gyro_var{}
 {
 }
 
@@ -40,24 +42,30 @@ void EwmaCovarianceProvider::addSample(const Vec3 & accel, const Vec3 & gyro)
     std::isnan(gyro.y) || std::isnan(gyro.z)) {
     return;
   }
+
+  // Skip non-stationary samples to avoid motion-induced variance inflation
+  if (!m_motion_detector.isStationary(accel, gyro)) {
+    return;
+  }
+
   // Only increment until warmup completes - prevents overflow
   if (m_sample_count < m_warmup_samples) {
     m_sample_count++;
   }
 
   if (m_sample_count == 1) {
-    //Initialize with first sample
+    // Initialize with first sample
     m_accel_mean = accel;
     m_gyro_mean = gyro;
     return;
   }
 
-  //EWMA mean update : mean_t = alpha * x_t + (1-alpha) * mean_{t-1}
+  // EWMA mean update: mean_t = alpha * x_t + (1-alpha) * mean_{t-1}
   auto updateMean = [this](double x, double & mean) {
     mean = m_alpha * x + (1.0 - m_alpha) * mean;
   };
 
-  //EWMA variance update: var_t = alpha * (x_t - mean_t)^2 + (1-alpha) * var_{t-1}
+  // EWMA variance update: var_t = alpha * (x_t - mean_t)^2 + (1-alpha) * var_{t-1}
   auto updateVar = [this](double x, double mean, double & var) {
     double diff = x - mean;
     var = m_alpha * (diff * diff) + (1.0 - m_alpha) * var;
@@ -99,10 +107,10 @@ CovarianceMatrix EwmaCovarianceProvider::getGyroCovariance() const
 void EwmaCovarianceProvider::reset()
 {
   m_sample_count = 0;
-  m_accel_mean = {0.0, 0.0, 0.0};
-  m_accel_var = {0.0, 0.0, 0.0};
-  m_gyro_mean = {0.0, 0.0, 0.0};
-  m_gyro_var = {0.0, 0.0, 0.0};
+  m_accel_mean = Vec3();
+  m_accel_var = Vec3();
+  m_gyro_mean = Vec3();
+  m_gyro_var = Vec3();
 }
 
 double EwmaCovarianceProvider::getCalibrationProgress() const

--- a/src/imu_covariance_factory.cpp
+++ b/src/imu_covariance_factory.cpp
@@ -18,6 +18,7 @@
 
 #include "adi_imu/ewma_covariance_provider.h"
 #include "adi_imu/kalman_covariance_provider.h"
+#include "adi_imu/motion_detector.h"
 #include "adi_imu/sliding_window_covariance_provider.h"
 #include "adi_imu/static_covariance_provider.h"
 #include "adi_imu/welford_covariance_provider.h"
@@ -45,15 +46,17 @@ std::unique_ptr<ImuCovarianceInterface> ImuCovarianceFactory::createFromParamete
   // Welford parameters
   node->declare_parameter(
     "covariance.welford.calibration_samples",
-    WelfordCovarianceProvider::DEFAULT_CALIBRATION_SAMPLES);
+    static_cast<int64_t>(WelfordCovarianceProvider::DEFAULT_CALIBRATION_SAMPLES));
   node->declare_parameter(
     "covariance.welford.min_variance", WelfordCovarianceProvider::DEFAULT_MIN_VARIANCE);
 
   // Sliding window parameters
   node->declare_parameter(
-    "covariance.sliding_window.window_size", SlidingWindowCovarianceProvider::DEFAULT_WINDOW_SIZE);
+    "covariance.sliding_window.window_size",
+    static_cast<int64_t>(SlidingWindowCovarianceProvider::DEFAULT_WINDOW_SIZE));
   node->declare_parameter(
-    "covariance.sliding_window.min_samples", SlidingWindowCovarianceProvider::DEFAULT_MIN_SAMPLES);
+    "covariance.sliding_window.min_samples",
+    static_cast<int64_t>(SlidingWindowCovarianceProvider::DEFAULT_MIN_SAMPLES));
   node->declare_parameter(
     "covariance.sliding_window.min_variance",
     SlidingWindowCovarianceProvider::DEFAULT_MIN_VARIANCE);
@@ -78,7 +81,8 @@ std::unique_ptr<ImuCovarianceInterface> ImuCovarianceFactory::createFromParamete
   // Exponentially-Weighted moving average (EWMA) covariance parameters
   node->declare_parameter("covariance.ewma.alpha", EwmaCovarianceProvider::DEFAULT_ALPHA);
   node->declare_parameter(
-    "covariance.ewma.warmup_samples", EwmaCovarianceProvider::DEFAULT_WARMUP_SAMPLES);
+    "covariance.ewma.warmup_samples",
+    static_cast<int64_t>(EwmaCovarianceProvider::DEFAULT_WARMUP_SAMPLES));
   node->declare_parameter(
     "covariance.ewma.min_variance", EwmaCovarianceProvider::DEFAULT_MIN_VARIANCE);
 
@@ -90,9 +94,17 @@ std::unique_ptr<ImuCovarianceInterface> ImuCovarianceFactory::createFromParamete
   node->declare_parameter(
     "covariance.kalman.initial_variance", KalmanCovarianceProvider::DEFAULT_INITIAL_VARIANCE);
   node->declare_parameter(
-    "covariance.kalman.warmup_samples", KalmanCovarianceProvider::DEFAULT_WARMUP_SAMPLES);
+    "covariance.kalman.warmup_samples",
+    static_cast<int64_t>(KalmanCovarianceProvider::DEFAULT_WARMUP_SAMPLES));
   node->declare_parameter(
     "covariance.kalman.min_variance", KalmanCovarianceProvider::DEFAULT_MIN_VARIANCE);
+
+  // Motion detection parameters (for adaptive algorithms)
+  node->declare_parameter("covariance.motion_detection.enable", true);
+  node->declare_parameter(
+    "covariance.motion_detection.gyro_threshold", MotionDetector::DEFAULT_GYRO_THRESHOLD);
+  node->declare_parameter(
+    "covariance.motion_detection.accel_threshold", MotionDetector::DEFAULT_ACCEL_THRESHOLD);
 
   // Check if covariance is enabled
   bool enable = node->get_parameter("covariance.enable").as_bool();
@@ -112,18 +124,34 @@ std::unique_ptr<ImuCovarianceInterface> ImuCovarianceFactory::createFromParamete
 std::unique_ptr<ImuCovarianceInterface> ImuCovarianceFactory::create(
   CovarianceAlgorithm algorithm, const std::shared_ptr<rclcpp::Node> & node)
 {
+  // Create motion detector from parameters
+  bool motion_detection_enable =
+    node->get_parameter("covariance.motion_detection.enable").as_bool();
+  double gyro_threshold =
+    node->get_parameter("covariance.motion_detection.gyro_threshold").as_double();
+  double accel_threshold =
+    node->get_parameter("covariance.motion_detection.accel_threshold").as_double();
+
+  MotionDetector motion_detector(gyro_threshold, accel_threshold);
+  motion_detector.setEnabled(motion_detection_enable);
+
+  if (motion_detection_enable) {
+    RCLCPP_INFO(
+      node->get_logger(),
+      "Motion detection enabled (gyro_threshold=%.4f rad/s, accel_threshold=%.4f m/s^2)",
+      gyro_threshold, accel_threshold);
+  }
+
   switch (algorithm) {
     case CovarianceAlgorithm::STATIC: {
-      Vec3 accel_var = {
-        node->get_parameter("covariance.static.accel_variance_x").as_double(),
-        node->get_parameter("covariance.static.accel_variance_y").as_double(),
-        node->get_parameter("covariance.static.accel_variance_z").as_double(),
-      };
-      Vec3 gyro_var = {
-        node->get_parameter("covariance.static.gyro_variance_x").as_double(),
-        node->get_parameter("covariance.static.gyro_variance_y").as_double(),
-        node->get_parameter("covariance.static.gyro_variance_z").as_double(),
-      };
+      Vec3 accel_var;
+      accel_var.x = node->get_parameter("covariance.static.accel_variance_x").as_double();
+      accel_var.y = node->get_parameter("covariance.static.accel_variance_y").as_double();
+      accel_var.z = node->get_parameter("covariance.static.accel_variance_z").as_double();
+      Vec3 gyro_var;
+      gyro_var.x = node->get_parameter("covariance.static.gyro_variance_x").as_double();
+      gyro_var.y = node->get_parameter("covariance.static.gyro_variance_y").as_double();
+      gyro_var.z = node->get_parameter("covariance.static.gyro_variance_z").as_double();
       return std::make_unique<StaticCovarianceProvider>(accel_var, gyro_var);
     }
     case CovarianceAlgorithm::WELFORD_ONLINE: {
@@ -140,14 +168,15 @@ std::unique_ptr<ImuCovarianceInterface> ImuCovarianceFactory::create(
       double min_variance =
         node->get_parameter("covariance.sliding_window.min_variance").as_double();
       return std::make_unique<SlidingWindowCovarianceProvider>(
-        window_size, min_samples, min_variance);
+        window_size, min_samples, min_variance, motion_detector);
     }
     case CovarianceAlgorithm::EWMA: {
       double alpha = node->get_parameter("covariance.ewma.alpha").as_double();
       size_t warmup_samples =
         static_cast<size_t>(node->get_parameter("covariance.ewma.warmup_samples").as_int());
       double min_variance = node->get_parameter("covariance.ewma.min_variance").as_double();
-      return std::make_unique<EwmaCovarianceProvider>(alpha, warmup_samples, min_variance);
+      return std::make_unique<EwmaCovarianceProvider>(
+        alpha, warmup_samples, min_variance, motion_detector);
     }
     case CovarianceAlgorithm::KALMAN: {
       double process_noise_q = node->get_parameter("covariance.kalman.process_noise_q").as_double();
@@ -159,7 +188,8 @@ std::unique_ptr<ImuCovarianceInterface> ImuCovarianceFactory::create(
         static_cast<size_t>(node->get_parameter("covariance.kalman.warmup_samples").as_int());
       double min_variance = node->get_parameter("covariance.kalman.min_variance").as_double();
       return std::make_unique<KalmanCovarianceProvider>(
-        process_noise_q, measurement_noise_r, initial_variance, warmup_samples, min_variance);
+        process_noise_q, measurement_noise_r, initial_variance, warmup_samples, min_variance,
+        motion_detector);
     }
   }
 

--- a/src/imu_covariance_factory.cpp
+++ b/src/imu_covariance_factory.cpp
@@ -1,0 +1,169 @@
+// Copyright 2025 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "adi_imu/imu_covariance_factory.h"
+
+#include <stdexcept>
+
+#include "adi_imu/ewma_covariance_provider.h"
+#include "adi_imu/kalman_covariance_provider.h"
+#include "adi_imu/sliding_window_covariance_provider.h"
+#include "adi_imu/static_covariance_provider.h"
+#include "adi_imu/welford_covariance_provider.h"
+
+namespace adi_imu
+{
+CovarianceAlgorithm ImuCovarianceFactory::parseAlgorithm(const std::string & algorithm_str)
+{
+  if (algorithm_str == "static") return CovarianceAlgorithm::STATIC;
+  if (algorithm_str == "welford") return CovarianceAlgorithm::WELFORD_ONLINE;
+  if (algorithm_str == "sliding_window") return CovarianceAlgorithm::SLIDING_WINDOW;
+  if (algorithm_str == "ewma") return CovarianceAlgorithm::EWMA;
+  if (algorithm_str == "kalman") return CovarianceAlgorithm::KALMAN;
+
+  throw std::invalid_argument("Unknown covariance algorithm: " + algorithm_str);
+}
+
+std::unique_ptr<ImuCovarianceInterface> ImuCovarianceFactory::createFromParameters(
+  const std::shared_ptr<rclcpp::Node> & node)
+{
+  //Declare parameters with defaults
+  node->declare_parameter("covariance.enable", false);
+  node->declare_parameter("covariance.algorithm", "welford");
+
+  // Welford parameters
+  node->declare_parameter(
+    "covariance.welford.calibration_samples",
+    WelfordCovarianceProvider::DEFAULT_CALIBRATION_SAMPLES);
+  node->declare_parameter(
+    "covariance.welford.min_variance", WelfordCovarianceProvider::DEFAULT_MIN_VARIANCE);
+
+  // Sliding window parameters
+  node->declare_parameter(
+    "covariance.sliding_window.window_size", SlidingWindowCovarianceProvider::DEFAULT_WINDOW_SIZE);
+  node->declare_parameter(
+    "covariance.sliding_window.min_samples", SlidingWindowCovarianceProvider::DEFAULT_MIN_SAMPLES);
+  node->declare_parameter(
+    "covariance.sliding_window.min_variance",
+    SlidingWindowCovarianceProvider::DEFAULT_MIN_VARIANCE);
+
+  // Static covariance parameters (diagonal values)
+  node->declare_parameter(
+    "covariance.static.accel_variance_x",
+    StaticCovarianceProvider::DEFAULT_STATIC_ACCEL_COVARIANCE);
+  node->declare_parameter(
+    "covariance.static.accel_variance_y",
+    StaticCovarianceProvider::DEFAULT_STATIC_ACCEL_COVARIANCE);
+  node->declare_parameter(
+    "covariance.static.accel_variance_z",
+    StaticCovarianceProvider::DEFAULT_STATIC_ACCEL_COVARIANCE);
+  node->declare_parameter(
+    "covariance.static.gyro_variance_x", StaticCovarianceProvider::DEFAULT_STATIC_GYRO_COVARIANCE);
+  node->declare_parameter(
+    "covariance.static.gyro_variance_y", StaticCovarianceProvider::DEFAULT_STATIC_GYRO_COVARIANCE);
+  node->declare_parameter(
+    "covariance.static.gyro_variance_z", StaticCovarianceProvider::DEFAULT_STATIC_GYRO_COVARIANCE);
+
+  // Exponentially-Weighted moving average (EWMA) covariance parameters
+  node->declare_parameter("covariance.ewma.alpha", EwmaCovarianceProvider::DEFAULT_ALPHA);
+  node->declare_parameter(
+    "covariance.ewma.warmup_samples", EwmaCovarianceProvider::DEFAULT_WARMUP_SAMPLES);
+  node->declare_parameter(
+    "covariance.ewma.min_variance", EwmaCovarianceProvider::DEFAULT_MIN_VARIANCE);
+
+  // Kalman filter covariance parameters
+  node->declare_parameter(
+    "covariance.kalman.process_noise_q", KalmanCovarianceProvider::DEFAULT_PROCESS_NOISE_Q);
+  node->declare_parameter(
+    "covariance.kalman.measurement_noise_r", KalmanCovarianceProvider::DEFAULT_MEASUREMENT_NOISE_R);
+  node->declare_parameter(
+    "covariance.kalman.initial_variance", KalmanCovarianceProvider::DEFAULT_INITIAL_VARIANCE);
+  node->declare_parameter(
+    "covariance.kalman.warmup_samples", KalmanCovarianceProvider::DEFAULT_WARMUP_SAMPLES);
+  node->declare_parameter(
+    "covariance.kalman.min_variance", KalmanCovarianceProvider::DEFAULT_MIN_VARIANCE);
+
+  // Check if covariance is enabled
+  bool enable = node->get_parameter("covariance.enable").as_bool();
+  if (!enable) {
+    RCLCPP_INFO(node->get_logger(), "Covariance computation disabled.");
+    return nullptr;
+  }
+
+  std::string algorithm_str = node->get_parameter("covariance.algorithm").as_string();
+  CovarianceAlgorithm algorithm = parseAlgorithm(algorithm_str);
+
+  RCLCPP_INFO(node->get_logger(), "Creating covariance provider: %s", algorithm_str.c_str());
+
+  return create(algorithm, node);
+}
+
+std::unique_ptr<ImuCovarianceInterface> ImuCovarianceFactory::create(
+  CovarianceAlgorithm algorithm, const std::shared_ptr<rclcpp::Node> & node)
+{
+  switch (algorithm) {
+    case CovarianceAlgorithm::STATIC: {
+      Vec3 accel_var = {
+        node->get_parameter("covariance.static.accel_variance_x").as_double(),
+        node->get_parameter("covariance.static.accel_variance_y").as_double(),
+        node->get_parameter("covariance.static.accel_variance_z").as_double(),
+      };
+      Vec3 gyro_var = {
+        node->get_parameter("covariance.static.gyro_variance_x").as_double(),
+        node->get_parameter("covariance.static.gyro_variance_y").as_double(),
+        node->get_parameter("covariance.static.gyro_variance_z").as_double(),
+      };
+      return std::make_unique<StaticCovarianceProvider>(accel_var, gyro_var);
+    }
+    case CovarianceAlgorithm::WELFORD_ONLINE: {
+      size_t calibration_samples =
+        static_cast<size_t>(node->get_parameter("covariance.welford.calibration_samples").as_int());
+      double min_variance = node->get_parameter("covariance.welford.min_variance").as_double();
+      return std::make_unique<WelfordCovarianceProvider>(calibration_samples, min_variance);
+    }
+    case CovarianceAlgorithm::SLIDING_WINDOW: {
+      size_t window_size =
+        static_cast<size_t>(node->get_parameter("covariance.sliding_window.window_size").as_int());
+      size_t min_samples =
+        static_cast<size_t>(node->get_parameter("covariance.sliding_window.min_samples").as_int());
+      double min_variance =
+        node->get_parameter("covariance.sliding_window.min_variance").as_double();
+      return std::make_unique<SlidingWindowCovarianceProvider>(
+        window_size, min_samples, min_variance);
+    }
+    case CovarianceAlgorithm::EWMA: {
+      double alpha = node->get_parameter("covariance.ewma.alpha").as_double();
+      size_t warmup_samples =
+        static_cast<size_t>(node->get_parameter("covariance.ewma.warmup_samples").as_int());
+      double min_variance = node->get_parameter("covariance.ewma.min_variance").as_double();
+      return std::make_unique<EwmaCovarianceProvider>(alpha, warmup_samples, min_variance);
+    }
+    case CovarianceAlgorithm::KALMAN: {
+      double process_noise_q = node->get_parameter("covariance.kalman.process_noise_q").as_double();
+      double measurement_noise_r =
+        node->get_parameter("covariance.kalman.measurement_noise_r").as_double();
+      double initial_variance =
+        node->get_parameter("covariance.kalman.initial_variance").as_double();
+      size_t warmup_samples =
+        static_cast<size_t>(node->get_parameter("covariance.kalman.warmup_samples").as_int());
+      double min_variance = node->get_parameter("covariance.kalman.min_variance").as_double();
+      return std::make_unique<KalmanCovarianceProvider>(
+        process_noise_q, measurement_noise_r, initial_variance, warmup_samples, min_variance);
+    }
+  }
+
+  return nullptr;
+}
+
+}  // namespace adi_imu

--- a/src/imu_data_provider.cpp
+++ b/src/imu_data_provider.cpp
@@ -51,10 +51,8 @@ bool ImuDataProvider::getData(sensor_msgs::msg::Imu & message)
   // Handle covariance if provider is set
   if (m_covariance_provider) {
     //Feed sample for calibration/adaptation
-    adi_imu::Vec3 accel = {
-      message.linear_acceleration.x, message.linear_acceleration.y, message.linear_acceleration.z};
-    adi_imu::Vec3 gyro = {
-      message.angular_velocity.x, message.angular_velocity.y, message.angular_velocity.z};
+    adi_imu::Vec3 accel = message.linear_acceleration;
+    adi_imu::Vec3 gyro = message.angular_velocity;
 
     m_covariance_provider->addSample(accel, gyro);
     if (m_covariance_provider->isReady()) {

--- a/src/imu_data_provider.cpp
+++ b/src/imu_data_provider.cpp
@@ -45,9 +45,43 @@ bool ImuDataProvider::getData(sensor_msgs::msg::Imu & message)
   message.header.frame_id = m_frame_id;
   m_iio_wrapper.getBuffSampleTimestamp(message.header.stamp.sec, message.header.stamp.nanosec);
 
+  // No orientation provided direclty by the IMU
   message.orientation_covariance[0] = -1;
 
+  // Handle covariance if provider is set
+  if (m_covariance_provider) {
+    //Feed sample for calibration/adaptation
+    adi_imu::Vec3 accel = {
+      message.linear_acceleration.x, message.linear_acceleration.y, message.linear_acceleration.z};
+    adi_imu::Vec3 gyro = {
+      message.angular_velocity.x, message.angular_velocity.y, message.angular_velocity.z};
+
+    m_covariance_provider->addSample(accel, gyro);
+    if (m_covariance_provider->isReady()) {
+      // Copy covariance to message
+      auto accel_cov = m_covariance_provider->getAccelCovariance();
+      auto gyro_cov = m_covariance_provider->getGyroCovariance();
+
+      std::copy(accel_cov.begin(), accel_cov.end(), message.linear_acceleration_covariance.begin());
+      std::copy(gyro_cov.begin(), gyro_cov.end(), message.angular_velocity_covariance.begin());
+    } else {
+      // Set to -1 to indicate unknown during calibration
+      message.linear_acceleration_covariance[0] = -1;
+      message.angular_velocity_covariance[0] = -1;
+    }
+  } else {
+    // No covariance provider - set to unknown
+    message.linear_acceleration_covariance[0] = -1;
+    message.angular_velocity_covariance[0] = -1;
+  }
+
   return true;
+}
+
+// Method for setting the covariance provider
+void ImuDataProvider::setCovarianceProvider(ImuCovarianceInterface * provider)
+{
+  m_covariance_provider = provider;
 }
 
 }  // namespace adi_imu

--- a/src/imu_ros2_node.cpp
+++ b/src/imu_ros2_node.cpp
@@ -22,6 +22,7 @@
 #include "adi_imu/adis_device_factory.h"
 #include "adi_imu/adis_register_map.h"
 #include "adi_imu/imu_control_parameters.h"
+#include "adi_imu/imu_covariance_factory.h"  // New covariance feature
 #include "adi_imu/imu_data_provider.h"
 #include "adi_imu/imu_diag_data_provider.h"
 #include "adi_imu/imu_diag_ros_publisher.h"
@@ -124,6 +125,22 @@ int main(int argc, char * argv[])
   imu_std_data_provider->setFrameId(frame_id);
   adi_imu::ImuRosPublisherInterface * imu_std_publisher = new adi_imu::ImuRosPublisher(imu_node);
   imu_std_publisher->setMessageProvider(imu_std_data_provider);
+
+  //==============Covariance provider setup================
+  // Create covariance provider from ROS2 parameters.
+  // The factory declares parameters and creates the appropriate provider
+  std::unique_ptr<adi_imu::ImuCovarianceInterface> covariance_provider =
+    adi_imu::ImuCovarianceFactory::createFromParameters(imu_node);
+
+  // Inject covariance provider into IMU data provider if enabled
+  if (covariance_provider) {
+    imu_std_data_provider->setCovarianceProvider(covariance_provider.get());
+    RCLCPP_INFO(imu_node->get_logger(), "Covariance provider attached to ImuDataProvider.");
+  } else {
+    RCLCPP_INFO(
+      imu_node->get_logger(), "Covariance computation disabled (covariance.enable = false).");
+  }
+  //=======================================================
 
   adi_imu::VelAngTempDataProviderInterface * vel_ang_data_provider = nullptr;
   adi_imu::VelAngTempRosPublisherInterface * vel_ang_publisher = nullptr;

--- a/src/kalman_covariance_provider.cpp
+++ b/src/kalman_covariance_provider.cpp
@@ -21,17 +21,19 @@
 
 #include <algorithm>
 #include <cmath>
+#include <utility>
 
 namespace adi_imu
 {
 
 KalmanCovarianceProvider::KalmanCovarianceProvider(
   double process_noise_q, double measurement_noise_r, double initial_variance,
-  size_t warmup_samples, double min_variance)
+  size_t warmup_samples, double min_variance, MotionDetector motion_detector)
 : m_process_noise_q(process_noise_q),
   m_measurement_noise_r(measurement_noise_r),
   m_initial_variance(initial_variance),
   m_min_variance(min_variance),
+  m_motion_detector(std::move(motion_detector)),
   m_warmup_samples(warmup_samples),
   m_sample_count(0)
 {
@@ -102,6 +104,11 @@ void KalmanCovarianceProvider::updateAxisFilter(AxisFilter & filter, double samp
 
 void KalmanCovarianceProvider::addSample(const Vec3 & accel, const Vec3 & gyro)
 {
+  // Skip non-stationary samples to avoid motion-induced variance inflation
+  if (!m_motion_detector.isStationary(accel, gyro)) {
+    return;
+  }
+
   // Update each axis filter
   updateAxisFilter(m_accel_x, accel.x);
   updateAxisFilter(m_accel_y, accel.y);

--- a/src/kalman_covariance_provider.cpp
+++ b/src/kalman_covariance_provider.cpp
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ *   @file   kalman_covariance_provider.cpp
+ *   @brief  Implementation of Kalman filter-based covariance estimation.
+ *   @author Tudor Alinei
+ *******************************************************************************/
+// Copyright 2026 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "adi_imu/kalman_covariance_provider.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace adi_imu
+{
+
+KalmanCovarianceProvider::KalmanCovarianceProvider(
+  double process_noise_q, double measurement_noise_r, double initial_variance,
+  size_t warmup_samples, double min_variance)
+: m_process_noise_q(process_noise_q),
+  m_measurement_noise_r(measurement_noise_r),
+  m_initial_variance(initial_variance),
+  m_min_variance(min_variance),
+  m_warmup_samples(warmup_samples),
+  m_sample_count(0)
+{
+  reset();
+}
+
+void KalmanCovarianceProvider::reset()
+{
+  m_sample_count = 0;
+
+  // Initialize all axis filters
+  auto initFilter = [this](AxisFilter & f) {
+    f.mean = 0.0;
+    f.variance = m_initial_variance;
+    f.error_covariance = m_initial_variance;  // Initial uncertainty in variance estimate
+  };
+
+  initFilter(m_accel_x);
+  initFilter(m_accel_y);
+  initFilter(m_accel_z);
+  initFilter(m_gyro_x);
+  initFilter(m_gyro_y);
+  initFilter(m_gyro_z);
+}
+
+void KalmanCovarianceProvider::updateAxisFilter(AxisFilter & filter, double sample)
+{
+  // Guard against NaN/Inf inputs
+  if (!std::isfinite(sample)) {
+    return;
+  }
+
+  // Update running mean using exponential moving average
+  // For first sample, initialize mean directly
+  if (m_sample_count == 0) {
+    filter.mean = sample;
+  } else {
+    filter.mean = (1.0 - MEAN_ALPHA) * filter.mean + MEAN_ALPHA * sample;
+  }
+
+  // Compute squared residual as measurement of variance
+  double residual = sample - filter.mean;
+  double measurement = residual * residual;
+
+  // === Kalman Filter Update ===
+
+  // Prediction step:
+  // State prediction: variance_predicted = variance (no change model)
+  // Error covariance prediction: P_predicted = P + Q
+  double P_predicted = filter.error_covariance + m_process_noise_q;
+
+  // Update step:
+  // Kalman gain: K = P_predicted / (P_predicted + R)
+  double K = P_predicted / (P_predicted + m_measurement_noise_r);
+
+  // State update: variance = variance + K * (measurement - variance)
+  filter.variance = filter.variance + K * (measurement - filter.variance);
+
+  // Error covariance update: P = (1 - K) * P_predicted (is equiv to the bellow form = Joseph form --more stable--)
+  filter.error_covariance = (1.0 - K) * P_predicted * (1.0 - K) + K * m_measurement_noise_r * K;
+
+  // Enforce minimum variance floor
+  filter.variance = std::max(filter.variance, m_min_variance);
+
+  // Ensure error covariance stays positive
+  filter.error_covariance = std::max(filter.error_covariance, m_min_variance);
+}
+
+void KalmanCovarianceProvider::addSample(const Vec3 & accel, const Vec3 & gyro)
+{
+  // Update each axis filter
+  updateAxisFilter(m_accel_x, accel.x);
+  updateAxisFilter(m_accel_y, accel.y);
+  updateAxisFilter(m_accel_z, accel.z);
+  updateAxisFilter(m_gyro_x, gyro.x);
+  updateAxisFilter(m_gyro_y, gyro.y);
+  updateAxisFilter(m_gyro_z, gyro.z);
+
+  // Increment sample count (cap to prevent overflow)
+  if (m_sample_count < m_warmup_samples) {
+    ++m_sample_count;
+  }
+}
+
+bool KalmanCovarianceProvider::isReady() const { return m_sample_count >= m_warmup_samples; }
+
+double KalmanCovarianceProvider::getCalibrationProgress() const
+{
+  if (m_warmup_samples == 0) {
+    return 1.0;
+  }
+  return std::min(1.0, static_cast<double>(m_sample_count) / static_cast<double>(m_warmup_samples));
+}
+
+CovarianceMatrix KalmanCovarianceProvider::buildCovarianceMatrix(
+  double var_x, double var_y, double var_z) const
+{
+  // Build diagonal covariance matrix (assuming independent axes)
+  // Layout: [xx, xy, xz, yx, yy, yz, zx, zy, zz]
+  return {var_x, 0.0, 0.0, 0.0, var_y, 0.0, 0.0, 0.0, var_z};
+}
+
+CovarianceMatrix KalmanCovarianceProvider::getAccelCovariance() const
+{
+  return buildCovarianceMatrix(m_accel_x.variance, m_accel_y.variance, m_accel_z.variance);
+}
+
+CovarianceMatrix KalmanCovarianceProvider::getGyroCovariance() const
+{
+  return buildCovarianceMatrix(m_gyro_x.variance, m_gyro_y.variance, m_gyro_z.variance);
+}
+
+}  // namespace adi_imu

--- a/src/motion_detector.cpp
+++ b/src/motion_detector.cpp
@@ -1,0 +1,55 @@
+// Copyright 2026 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "adi_imu/motion_detector.h"
+
+#include <cmath>
+
+namespace adi_imu
+{
+
+MotionDetector::MotionDetector(double gyro_threshold, double accel_threshold)
+: m_gyro_threshold(gyro_threshold), m_accel_threshold(accel_threshold), m_enabled(true)
+{
+}
+
+bool MotionDetector::isStationary(const Vec3 & accel, const Vec3 & gyro) const
+{
+  // If motion detection is disabled, always return stationary
+  if (!m_enabled) {
+    return true;
+  }
+
+  // Check gyroscope magnitude
+  double gyro_magnitude = std::sqrt(gyro.x * gyro.x + gyro.y * gyro.y + gyro.z * gyro.z);
+  if (gyro_magnitude > m_gyro_threshold) {
+    return false;
+  }
+
+  // Check accelerometer deviation from gravity
+  // When stationary, accel magnitude should be close to gravity
+  double accel_magnitude = std::sqrt(accel.x * accel.x + accel.y * accel.y + accel.z * accel.z);
+  double accel_deviation = std::abs(accel_magnitude - GRAVITY_MAGNITUDE);
+  if (accel_deviation > m_accel_threshold) {
+    return false;
+  }
+
+  return true;
+}
+
+void MotionDetector::setGyroThreshold(double threshold) { m_gyro_threshold = threshold; }
+
+void MotionDetector::setAccelThreshold(double threshold) { m_accel_threshold = threshold; }
+
+}  // namespace adi_imu

--- a/src/sliding_window_covariance_provider.cpp
+++ b/src/sliding_window_covariance_provider.cpp
@@ -1,0 +1,155 @@
+// Copyright 2025 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "adi_imu/sliding_window_covariance_provider.h"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+
+namespace adi_imu
+{
+SlidingWindowCovarianceProvider::SlidingWindowCovarianceProvider(
+  size_t window_size, size_t min_samples, double min_variance)
+: m_window_size(window_size),
+  m_min_samples(min_samples),
+  m_min_variance(min_variance),
+  m_accel_covariance{},
+  m_gyro_covariance{},
+  m_update_interval(50),
+  m_samples_since_update(0)
+{
+}
+
+void SlidingWindowCovarianceProvider::addSample(const Vec3 & accel, const Vec3 & gyro)
+{
+  // Guard against NaN from sensor
+  if (
+    std::isnan(accel.x) || std::isnan(accel.y) || std::isnan(accel.z) || std::isnan(gyro.x) ||
+    std::isnan(gyro.y) || std::isnan(gyro.z)) {
+    return;
+  }
+
+  // Add to buffers
+  m_accel_samples.push_back(accel);
+  m_gyro_samples.push_back(gyro);
+
+  // Maintain window size
+  if (m_accel_samples.size() > m_window_size) {
+    m_accel_samples.pop_front();
+    m_gyro_samples.pop_front();
+  }
+
+  // Recompute periodically for efficiency
+  m_samples_since_update++;
+  if (m_samples_since_update >= m_update_interval && isReady()) {
+    recomputeCovariance();
+    m_samples_since_update = 0;
+  }
+}
+
+bool SlidingWindowCovarianceProvider::isReady() const
+{
+  return m_accel_samples.size() >= m_min_samples;
+}
+
+void SlidingWindowCovarianceProvider::recomputeCovariance()
+{
+  size_t n = m_accel_samples.size();
+  if (n < 2) {
+    return;
+  }
+
+  // Compute means
+  Vec3 accel_mean = {0.0, 0.0, 0.0};
+  Vec3 gyro_mean = {0.0, 0.0, 0.0};
+
+  for (const auto & s : m_accel_samples) {
+    accel_mean.x += s.x;
+    accel_mean.y += s.y;
+    accel_mean.z += s.z;
+  }
+
+  for (const auto & s : m_gyro_samples) {
+    gyro_mean.x += s.x;
+    gyro_mean.y += s.y;
+    gyro_mean.z += s.z;
+  }
+
+  double dn = static_cast<double>(n);
+  accel_mean.x /= dn;
+  accel_mean.y /= dn;
+  accel_mean.z /= dn;
+  gyro_mean.x /= dn;
+  gyro_mean.y /= dn;
+  gyro_mean.z /= dn;
+
+  // Compute variances
+  Vec3 accel_var = {0.0, 0.0, 0.0};
+  Vec3 gyro_var = {0.0, 0.0, 0.0};
+
+  for (const auto & s : m_accel_samples) {
+    accel_var.x += (s.x - accel_mean.x) * (s.x - accel_mean.x);
+    accel_var.y += (s.y - accel_mean.y) * (s.y - accel_mean.y);
+    accel_var.z += (s.z - accel_mean.z) * (s.z - accel_mean.z);
+  }
+
+  for (const auto & s : m_gyro_samples) {
+    gyro_var.x += (s.x - gyro_mean.x) * (s.x - gyro_mean.x);
+    gyro_var.y += (s.y - gyro_mean.y) * (s.y - gyro_mean.y);
+    gyro_var.z += (s.z - gyro_mean.z) * (s.z - gyro_mean.z);
+  }
+
+  // Applying Bessel correction for unbiased variance
+  double dn1 = static_cast<double>(n - 1);
+  accel_var.x = std::max(accel_var.x / dn1, m_min_variance);
+  accel_var.y = std::max(accel_var.y / dn1, m_min_variance);
+  accel_var.z = std::max(accel_var.z / dn1, m_min_variance);
+  gyro_var.x = std::max(gyro_var.x / dn1, m_min_variance);
+  gyro_var.y = std::max(gyro_var.y / dn1, m_min_variance);
+  gyro_var.z = std::max(gyro_var.z / dn1, m_min_variance);
+
+  m_accel_covariance = {accel_var.x, 0.0, 0.0, 0.0, accel_var.y, 0.0, 0.0, 0.0, accel_var.z};
+
+  m_gyro_covariance = {gyro_var.x, 0.0, 0.0, 0.0, gyro_var.y, 0.0, 0.0, 0.0, gyro_var.z};
+}
+
+CovarianceMatrix SlidingWindowCovarianceProvider::getAccelCovariance() const
+{
+  return m_accel_covariance;
+}
+
+CovarianceMatrix SlidingWindowCovarianceProvider::getGyroCovariance() const
+{
+  return m_gyro_covariance;
+}
+
+void SlidingWindowCovarianceProvider::reset()
+{
+  m_accel_samples.clear();
+  m_gyro_samples.clear();
+  m_accel_covariance = {};
+  m_gyro_covariance = {};
+  m_samples_since_update = 0;
+}
+
+double SlidingWindowCovarianceProvider::getCalibrationProgress() const
+{
+  if (m_accel_samples.size() >= m_min_samples) {
+    return 1.0;
+  }
+  return static_cast<double>(m_accel_samples.size()) / static_cast<double>(m_min_samples);
+}
+
+}  // namespace adi_imu

--- a/src/sliding_window_covariance_provider.cpp
+++ b/src/sliding_window_covariance_provider.cpp
@@ -17,14 +17,16 @@
 #include <algorithm>
 #include <cmath>
 #include <numeric>
+#include <utility>
 
 namespace adi_imu
 {
 SlidingWindowCovarianceProvider::SlidingWindowCovarianceProvider(
-  size_t window_size, size_t min_samples, double min_variance)
+  size_t window_size, size_t min_samples, double min_variance, MotionDetector motion_detector)
 : m_window_size(window_size),
   m_min_samples(min_samples),
   m_min_variance(min_variance),
+  m_motion_detector(std::move(motion_detector)),
   m_accel_covariance{},
   m_gyro_covariance{},
   m_update_interval(50),
@@ -38,6 +40,11 @@ void SlidingWindowCovarianceProvider::addSample(const Vec3 & accel, const Vec3 &
   if (
     std::isnan(accel.x) || std::isnan(accel.y) || std::isnan(accel.z) || std::isnan(gyro.x) ||
     std::isnan(gyro.y) || std::isnan(gyro.z)) {
+    return;
+  }
+
+  // Skip non-stationary samples to avoid motion-induced variance inflation
+  if (!m_motion_detector.isStationary(accel, gyro)) {
     return;
   }
 
@@ -72,8 +79,8 @@ void SlidingWindowCovarianceProvider::recomputeCovariance()
   }
 
   // Compute means
-  Vec3 accel_mean = {0.0, 0.0, 0.0};
-  Vec3 gyro_mean = {0.0, 0.0, 0.0};
+  Vec3 accel_mean{};
+  Vec3 gyro_mean{};
 
   for (const auto & s : m_accel_samples) {
     accel_mean.x += s.x;
@@ -96,8 +103,8 @@ void SlidingWindowCovarianceProvider::recomputeCovariance()
   gyro_mean.z /= dn;
 
   // Compute variances
-  Vec3 accel_var = {0.0, 0.0, 0.0};
-  Vec3 gyro_var = {0.0, 0.0, 0.0};
+  Vec3 accel_var{};
+  Vec3 gyro_var{};
 
   for (const auto & s : m_accel_samples) {
     accel_var.x += (s.x - accel_mean.x) * (s.x - accel_mean.x);

--- a/src/static_covariance_provider.cpp
+++ b/src/static_covariance_provider.cpp
@@ -1,0 +1,52 @@
+// Copyright 2025 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "adi_imu/static_covariance_provider.h"
+
+namespace adi_imu
+{
+StaticCovarianceProvider::StaticCovarianceProvider(
+  const Vec3 & accel_variance, const Vec3 & gyro_variance)
+{
+  // Create diagonal covariance matrices
+  m_accel_covariance = {accel_variance.x, 0.0, 0.0, 0.0, accel_variance.y, 0.0, 0.0, 0.0,
+                        accel_variance.z};
+  m_gyro_covariance = {gyro_variance.x, 0.0, 0.0, 0.0, gyro_variance.y, 0.0, 0.0, 0.0,
+                       gyro_variance.z};
+}
+
+StaticCovarianceProvider::StaticCovarianceProvider(
+  const CovarianceMatrix & accel_cov, const CovarianceMatrix & gyro_cov)
+: m_accel_covariance(accel_cov), m_gyro_covariance(gyro_cov)
+{
+}
+
+void StaticCovarianceProvider::addSample(const Vec3 &, const Vec3 &)
+{
+  // Nothing to add here for the static covariances
+}
+
+bool StaticCovarianceProvider::isReady() const { return true; }
+
+CovarianceMatrix StaticCovarianceProvider::getAccelCovariance() const { return m_accel_covariance; }
+
+CovarianceMatrix StaticCovarianceProvider::getGyroCovariance() const { return m_gyro_covariance; }
+
+void StaticCovarianceProvider::reset()
+{
+  // No-op for static provider
+}
+
+double StaticCovarianceProvider::getCalibrationProgress() const { return 1.0; }
+}  // namespace adi_imu

--- a/src/welford_covariance_provider.cpp
+++ b/src/welford_covariance_provider.cpp
@@ -24,10 +24,10 @@ WelfordCovarianceProvider::WelfordCovarianceProvider(
 : m_target_samples(calibration_samples),
   m_sample_count(0),
   m_min_variance(min_variance),
-  m_accel_mean{0.0, 0.0, 0.0},
-  m_accel_M2{0.0, 0.0, 0.0},
-  m_gyro_mean{0.0, 0.0, 0.0},
-  m_gyro_M2{0.0, 0.0, 0.0},
+  m_accel_mean{},
+  m_accel_M2{},
+  m_gyro_mean{},
+  m_gyro_M2{},
   m_accel_covariance{},
   m_gyro_covariance{},
   m_calibration_complete(false)
@@ -109,10 +109,10 @@ CovarianceMatrix WelfordCovarianceProvider::getGyroCovariance() const { return m
 void WelfordCovarianceProvider::reset()
 {
   m_sample_count = 0;
-  m_accel_mean = {0.0, 0.0, 0.0};
-  m_accel_M2 = {0.0, 0.0, 0.0};
-  m_gyro_mean = {0.0, 0.0, 0.0};
-  m_gyro_M2 = {0.0, 0.0, 0.0};
+  m_accel_mean = Vec3();
+  m_accel_M2 = Vec3();
+  m_gyro_mean = Vec3();
+  m_gyro_M2 = Vec3();
   m_accel_covariance = {};
   m_gyro_covariance = {};
   m_calibration_complete = false;

--- a/src/welford_covariance_provider.cpp
+++ b/src/welford_covariance_provider.cpp
@@ -1,0 +1,129 @@
+// Copyright 2025 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "adi_imu/welford_covariance_provider.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace adi_imu
+{
+WelfordCovarianceProvider::WelfordCovarianceProvider(
+  size_t calibration_samples, double min_variance)
+: m_target_samples(calibration_samples),
+  m_sample_count(0),
+  m_min_variance(min_variance),
+  m_accel_mean{0.0, 0.0, 0.0},
+  m_accel_M2{0.0, 0.0, 0.0},
+  m_gyro_mean{0.0, 0.0, 0.0},
+  m_gyro_M2{0.0, 0.0, 0.0},
+  m_accel_covariance{},
+  m_gyro_covariance{},
+  m_calibration_complete(false)
+{
+}
+
+void WelfordCovarianceProvider::updateWelford(double value, double & mean, double & M2, size_t n)
+{
+  double delta = value - mean;
+  mean += delta / static_cast<double>(n);
+  double delta2 = value - mean;
+  M2 += delta * delta2;
+}
+
+double WelfordCovarianceProvider::computeVariance(double M2, size_t n) const
+{
+  if (n < 2) {
+    return m_min_variance;
+  }
+  // Using unbiased sample variance
+  double variance = M2 / static_cast<double>(n - 1);
+  return std::max(variance, m_min_variance);
+}
+
+void WelfordCovarianceProvider::addSample(const Vec3 & accel, const Vec3 & gyro)
+{
+  // Guard against NaN from sensor
+  if (
+    std::isnan(accel.x) || std::isnan(accel.y) || std::isnan(accel.z) || std::isnan(gyro.x) ||
+    std::isnan(gyro.y) || std::isnan(gyro.z)) {
+    return;
+  }
+
+  if (m_calibration_complete) {
+    return;
+  }
+
+  m_sample_count++;
+  size_t n = m_sample_count;
+
+  // Update accelerometer statistics
+  updateWelford(accel.x, m_accel_mean.x, m_accel_M2.x, n);
+  updateWelford(accel.y, m_accel_mean.y, m_accel_M2.y, n);
+  updateWelford(accel.z, m_accel_mean.z, m_accel_M2.z, n);
+
+  // Update gyro statistics
+  updateWelford(gyro.x, m_gyro_mean.x, m_gyro_M2.x, n);
+  updateWelford(gyro.y, m_gyro_mean.y, m_gyro_M2.y, n);
+  updateWelford(gyro.z, m_gyro_mean.z, m_gyro_M2.z, n);
+
+  // Check if calibration is complete
+  if (m_target_samples <= m_sample_count) {
+    // Freeze covariance as diag. matrices
+    double ax_var = computeVariance(m_accel_M2.x, n);
+    double ay_var = computeVariance(m_accel_M2.y, n);
+    double az_var = computeVariance(m_accel_M2.z, n);
+
+    double gx_var = computeVariance(m_gyro_M2.x, n);
+    double gy_var = computeVariance(m_gyro_M2.y, n);
+    double gz_var = computeVariance(m_gyro_M2.z, n);
+
+    m_accel_covariance = {ax_var, 0.0, 0.0, 0.0, ay_var, 0.0, 0.0, 0.0, az_var};
+
+    m_gyro_covariance = {gx_var, 0.0, 0.0, 0.0, gy_var, 0.0, 0.0, 0.0, gz_var};
+
+    m_calibration_complete = true;
+  }
+}
+
+bool WelfordCovarianceProvider::isReady() const { return m_calibration_complete; }
+
+CovarianceMatrix WelfordCovarianceProvider::getAccelCovariance() const
+{
+  return m_accel_covariance;
+}
+
+CovarianceMatrix WelfordCovarianceProvider::getGyroCovariance() const { return m_gyro_covariance; }
+
+void WelfordCovarianceProvider::reset()
+{
+  m_sample_count = 0;
+  m_accel_mean = {0.0, 0.0, 0.0};
+  m_accel_M2 = {0.0, 0.0, 0.0};
+  m_gyro_mean = {0.0, 0.0, 0.0};
+  m_gyro_M2 = {0.0, 0.0, 0.0};
+  m_accel_covariance = {};
+  m_gyro_covariance = {};
+  m_calibration_complete = false;
+}
+
+double WelfordCovarianceProvider::getCalibrationProgress() const
+{
+  if (m_calibration_complete) {
+    return 1.0;
+  }
+  return static_cast<double>(m_sample_count) / static_cast<double>(m_target_samples);
+}
+
+}  // namespace adi_imu


### PR DESCRIPTION
I added a few algorithms for covariance computation. The user can choose the desired covariance algorithm by passing the covariance_algorithm parameter to the imu_and_covariance.launch.py or by directly providing the covariance.algorithm parameter to adi_imu_node. There are specific filtering parameters for each covariance estimator, and, moreover, the covariance.enable (for adi_imu_node)/covariance_enable (imu_and_covariance.launch.py) parameter enable/disable the covariance computation and publishing.

Angular velocity and acceleration covariances are bounded to the /imu topic (this topic is remapped to /imu/data_raw when using imu_and_covariance.launch.py launch file).

The following covariance algorithms were integrated inside the node:
- Static covariance (user can specifi the covariance of angular velocities and accelerations at launch-time)
- Welford: sensor covariances are estimated using the first samples provided by the IMU (sensor should be stationary during this time)
- Sliding window covariance: Covariance is dynamically computed during operation time
- Exponentially weighted moving average (EWMA):  Mean and sensor variance are computed dynamically (simmilar to sliding window) but using EWMA algorithm which is O(1) compared to sliding window which is O(samples_per_window)
- Kalman filter covariance estimator