### PR TITLE
imu_ros2_node: Fix double-free of data providers

### DIFF
--- a/src/imu_ros2_node.cpp
+++ b/src/imu_ros2_node.cpp
@@ -208,24 +208,11 @@ int main(int argc, char * argv[])
   }
   publisher_group_thread.join();
 
-  // Cleanup resources
-  if (device_descriptor->has(adi_imu::ADISRegister::HAS_DELTA_BURST)) {
-    if (vel_ang_data_provider != nullptr) {
-      delete vel_ang_data_provider;
-    }
-    if (vel_ang_publisher != nullptr) {
-      delete vel_ang_publisher;
-    }
+  // Cleanup resources. Deleting publishers also deletes their respective providers
+  if (vel_ang_publisher != nullptr) {
+    delete vel_ang_publisher;
   }
-  delete full_data_provider;
-  delete imu_std_data_provider;
 
-  if (diag_data_enable) {
-    delete diag_data_provider;
-  }
-  if (ident_data_provider != nullptr) {
-    delete ident_data_provider;
-  }
   if (ident_publisher != nullptr) {
     delete ident_publisher;
   }


### PR DESCRIPTION
Publishers effectively take ownership of their data providers and delete them in their respective destructors. E.g.:

https://github.com/analogdevicesinc/imu_ros2/blob/365b399172d19e21627f3ba76fa59cb04a599c5e/src/imu_ros_publisher.cpp#L34

Deleting both publishers and their providers constitutes a double free and causes a SIGSEGV:

https://github.com/analogdevicesinc/imu_ros2/blob/365b399172d19e21627f3ba76fa59cb04a599c5e/src/imu_ros2_node.cpp#L212-L235

I think the most idiomatic fix would be to change all this pointer passing to C++ smart pointers with proper ownership semantics, but that would break API & ABI compatibility. Inside main(), pointers are in a bit too much spaghetti to be able to be easily just converted to shared_ptr or unique_ptr without modifying Intarfaces' APIs.

This PR:
* leaves the publisher interfaces untouched
* removes explicit provider deletion, delegating that to the publisher destructors